### PR TITLE
Update samples to .NET 10 in docs and dev containers

### DIFF
--- a/.devcontainer/attribute-array/devcontainer.json
+++ b/.devcontainer/attribute-array/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Attribute array pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/attribute-array/source/",
     "postAttachCommand": "dotnet build AttributeArray.csproj",

--- a/.devcontainer/data-binning/devcontainer.json
+++ b/.devcontainer/data-binning/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Data binning pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/data-binning/source/",
     "postAttachCommand": "dotnet build DataBinning.csproj",

--- a/.devcontainer/distributed-counter/devcontainer.json
+++ b/.devcontainer/distributed-counter/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Distributed counter pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/distributed-counter/source/",
     "postAttachCommand": "dotnet build DistributedCounter.sln",

--- a/.devcontainer/distributed-lock/devcontainer.json
+++ b/.devcontainer/distributed-lock/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Distributed lock pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/distributed-lock/source/",
     "postAttachCommand": "dotnet build GlobalLock.csproj",

--- a/.devcontainer/document-versioning/devcontainer.json
+++ b/.devcontainer/document-versioning/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Document versioning pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/document-versioning/source",
     "postAttachCommand": "dotnet build website/website.csproj",

--- a/.devcontainer/event-sourcing/devcontainer.json
+++ b/.devcontainer/event-sourcing/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Event sourcing pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/event-sourcing/source/",
     "postAttachCommand": "dotnet build EventSourcing.csproj",

--- a/.devcontainer/materialized-view/devcontainer.json
+++ b/.devcontainer/materialized-view/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Materialized view pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/materialized-view/source/",
     "postAttachCommand": "dotnet build data-generator/data-generator.csproj && dotnet build function-app/MaterializeViews.csproj",

--- a/.devcontainer/preallocation/devcontainer.json
+++ b/.devcontainer/preallocation/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Preallocation pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/preallocation/source/",
     "postAttachCommand": "dotnet build Preallocation.csproj",

--- a/.devcontainer/schema-versioning/devcontainer.json
+++ b/.devcontainer/schema-versioning/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Schema versioning pattern",
-    "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace/schema-versioning/source/",
     "postAttachCommand": "dotnet build data-generator/data-generator.csproj && dotnet build website/website.csproj",

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Dive into the `schema-versioning` folder to learn how to manage changes to your 
 ### Prerequisites
 If running locally you will need to install some pre-requistes.
 
-- [.NET 8.0 Runtime](https://dotnet.microsoft.com/download)
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools)
 
 To confirm you have the required versions of the tools installed.
 
-First, check the .NET runtime with this command. Make sure that .NET components with versions that start with 8.0 appear as part of the output:
+First, check the .NET runtime with this command. Make sure that .NET components with versions that start with 10.0 appear as part of the output:
 
 ```bash
 dotnet --list-runtimes

--- a/materialized-view/README.md
+++ b/materialized-view/README.md
@@ -76,7 +76,7 @@ In the demo, you will not notice the performance implications with smaller sets 
 
 To run this demo, you will need to have:
 
-- [.NET 8.0 Runtime](https://dotnet.microsoft.com/download)
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 - [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools)
 
 ## Confirm required tools are installed

--- a/preallocation/README.md
+++ b/preallocation/README.md
@@ -202,7 +202,7 @@ By not choosing the pre-allocation pattern, the alternative way to find availabl
 
 To run this demo, you will need to have:
 
-- [.NET 8.0 Runtime](https://dotnet.microsoft.com/download)
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 
 ## Confirm required tools are installed
 
@@ -214,7 +214,7 @@ First, check the .NET runtime with this command:
 dotnet --list-runtimes
 ```
 
-As you may have multiple versions of the runtime installed, make sure that .NET components with versions that start with 8.0 appear as part of the output.
+As you may have multiple versions of the runtime installed, make sure that .NET components with versions that start with 10.0 appear as part of the output.
 
 ## Getting the code
 

--- a/schema-versioning/README.md
+++ b/schema-versioning/README.md
@@ -171,13 +171,13 @@ Open the application code in GitHub Codespaces:
 
 ### Prerequisites
 
-If running locally you will need to install .NET 8.
+If running locally you will need to install .NET 10.
 
-- [.NET 8.0 Runtime](https://dotnet.microsoft.com/download)
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
 
 To confirm you have the required versions of the tools installed.
 
-First, check the .NET runtime with this command. Make sure that .NET components with versions that start with 8.0 appear as part of the output:
+First, check the .NET runtime with this command. Make sure that .NET components with versions that start with 10.0 appear as part of the output:
 
 ```bash
 dotnet --list-runtimes


### PR DESCRIPTION
Aligns documentation and dev container images with the sample projects, which already target 
et10.0.

- README and the per-pattern READMEs (materialized-view, preallocation, schema-versioning) now reference the .NET 10 SDK, with an updated download link and version-check text.
- All 9 dev containers now use `mcr.microsoft.com/devcontainers/dotnet:10.0` (this also normalizes the former `1-8.0-bookworm` image to the same tag).

No source/csproj changes were needed — the projects already target `net10.0`.

Fixes #76