### PR TITLE
Fix event-sourcing 400 BadRequest on Cosmos write (#69)

### DIFF
--- a/event-sourcing/source/CartEvent.cs
+++ b/event-sourcing/source/CartEvent.cs
@@ -5,6 +5,7 @@ namespace EventSourcing
     public class CartEvent
     {
         [JsonProperty("id")]
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
         public string Id { get; set; } = Guid.NewGuid().ToString();
         public string CartId { get; set; } = Guid.NewGuid().ToString();  //Partition Key
         public string SessionId { get; set; } = Guid.NewGuid().ToString();

--- a/event-sourcing/source/EventSourceFunction.cs
+++ b/event-sourcing/source/EventSourceFunction.cs
@@ -19,35 +19,44 @@ namespace EventSourcing
         }
 
         [Function("EventSourcing")]
-        [CosmosDBOutput(
-                databaseName: "EventSourcingDB",
-                containerName: "CartEvents",
-                Connection = "CosmosDBConnection",
-                CreateIfNotExists = true,
-                PartitionKey = "/CartId")]
-        public async Task<IActionResult> Run(
+        public async Task<EventSourcingOutput> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req, 
                 FunctionContext context)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            string responseMessage;
 
-            if (requestBody != null)
+            if (string.IsNullOrEmpty(requestBody))
             {
-                CartEvent cartEvent = JsonConvert.DeserializeObject<CartEvent>(requestBody) ?? throw new ArgumentException("Request body is empty");
-                _logger.LogInformation(JsonConvert.SerializeObject(cartEvent, Formatting.Indented));
-
-                //responseMessage = $"HTTP function successful for event {cartEvent.EventType} for cart {cartEvent.CartId}.";
-                return new OkObjectResult(cartEvent);
-            }
-            else
-            {
-                responseMessage = "No event sent in body";
+                return new EventSourcingOutput
+                {
+                    HttpResponse = new OkObjectResult("No event sent in body")
+                };
             }
 
-            return new OkObjectResult(responseMessage);
+            CartEvent cartEvent = JsonConvert.DeserializeObject<CartEvent>(requestBody) ?? throw new ArgumentException("Request body is empty");
+            _logger.LogInformation(JsonConvert.SerializeObject(cartEvent, Formatting.Indented));
+
+            return new EventSourcingOutput
+            {
+                CartEvent = cartEvent,
+                HttpResponse = new OkObjectResult(cartEvent)
+            };
         }
+    }
+
+    public class EventSourcingOutput
+    {
+        [CosmosDBOutput(
+            databaseName: "EventSourcingDB",
+            containerName: "CartEvents",
+            Connection = "CosmosDBConnection",
+            CreateIfNotExists = true,
+            PartitionKey = "/CartId")]
+        public CartEvent? CartEvent { get; set; }
+
+        [HttpResult]
+        public IActionResult HttpResponse { get; set; } = new OkResult();
     }
 }

--- a/event-sourcing/source/EventSourcing.csproj
+++ b/event-sourcing/source/EventSourcing.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.16.1" />
   </ItemGroup>


### PR DESCRIPTION
## Problem

Running the event-sourcing sample and POSTing cart events fails with:

`Microsoft.Azure.Cosmos.Client: Response status code does not indicate success: BadRequest (400); Reason: {"Errors":["One of the specified inputs is invalid"]}`

## Root causes

1. **`id` casing.** The .NET **isolated** worker serializes Cosmos output bindings with **System.Text.Json**, which ignores the Newtonsoft `[JsonProperty("id")]` on `CartEvent.Id`. The document was written with a PascalCase `"Id"` instead of the required lowercase `"id"`, so Cosmos rejected it (the specific SDK error is *"the required properties - 'id;' - are missing"*).
2. **Wrong output object.** `[CosmosDBOutput]` was applied to a method returning `IActionResult`, so the binding received the `OkObjectResult` wrapper rather than the `CartEvent`.

## Changes

- `CartEvent.Id`: add `[System.Text.Json.Serialization.JsonPropertyName("id")]` so the binding serializer emits lowercase `id`.
- `EventSourceFunction`: return a multi-output type (`CartEvent` on the `[CosmosDBOutput]` property + `[HttpResult]` HTTP response) so the `CartEvent` is written.
- Pin `Microsoft.ApplicationInsights.WorkerService` to `2.23.0`. Version `3.1.2` (App Insights SDK 3.x) is incompatible with `Microsoft.Azure.Functions.Worker.ApplicationInsights 2.51.0` and threw a `TypeLoadException` (`ITelemetryInitializer`) on host startup.

## Verification

Reproduced end to end with `func start` against a real Cosmos DB account: before the fix, POST → 400; after, POST → **HTTP 200**, function **Succeeded**, and the document persisted with a lowercase `id` and correct `CartId` (confirmed via a read-back).

Fixes #69