### PR TITLE
Support environment variables for configuration (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,22 @@ All of these design patterns are built to run from a single Serverless Azure Cos
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgithub.com%2FAzureCosmosDB%2Fdesign-patterns%2Ftree%2Fmain%2Fazuredeploy.json)
 
-#### Authentication options
+#### Configuration and authentication
 
-Each sample supports two authentication methods — RBAC (keyless) is the recommended approach:
+Each sample reads its Azure Cosmos DB endpoint (and, optionally, an account key) from configuration. The **recommended way to supply these values for local development is environment variables** — they keep secrets out of the source tree and work well with the emulator, containers, and CI. Every sample still also reads `appsettings.development.json` (git-ignored) as a file-based fallback if you prefer it.
+
+The console and data-generator samples bind these values at the root of configuration; the website samples bind them under a `CosmosDb` section (so their environment variables use the `__` separator). The Functions samples (`event-sourcing`, `materialized-view`) use `local.settings.json` / `CosmosDBConnection`.
+
+| Sample type | Endpoint variable | Key variable (optional) |
+| --- | --- | --- |
+| Console / data-generator | `CosmosUri` | `CosmosKey` |
+| Website (Razor/Blazor) | `CosmosDb__CosmosUri` | `CosmosDb__CosmosKey` |
+
+> Some samples read additional root-level settings (for example `distributed-lock` and `distributed-counter` use `CosmosDatabase` and `CosmosContainer`). See each sample's README for its full list.
 
 **Option 1: Keyless authentication via RBAC (Recommended)**
 
-The samples use `DefaultAzureCredential` from `Azure.Identity`. When `CosmosKey` is left empty (or omitted), the application automatically uses RBAC-based authentication. This works with:
+The samples use `DefaultAzureCredential` from `Azure.Identity`. When the key is left empty (or unset), the application automatically uses RBAC-based authentication. This works with:
 - Azure managed identity (when hosted in Azure)
 - Azure CLI credentials (`az login`) for local development
 
@@ -154,11 +163,31 @@ az cosmosdb sql role assignment create \
   --scope "/"
 ```
 
+Then set only the endpoint (console/data-generator example shown):
+
+```powershell
+# PowerShell
+$env:CosmosUri = "<endpoint>"
+```
+```bash
+# bash
+export CosmosUri="<endpoint>"
+```
+
 **Option 2: Key-based authentication (local emulator fallback)**
 
-Set `CosmosKey` in your `appsettings.development.json` (never commit this file) when using the Azure Cosmos DB Emulator or when RBAC is not available. See individual sample READMEs for the exact configuration format.
+When using the Azure Cosmos DB Emulator or when RBAC is not available, also set the key:
 
-> **Security note:** Never commit your Cosmos DB primary key or connection string to source control. The `.gitignore` already excludes `appsettings.development.json` and `local.settings.json`.
+```powershell
+# PowerShell
+$env:CosmosUri = "<endpoint>"; $env:CosmosKey = "<primary-key>"
+```
+```bash
+# bash
+export CosmosUri="<endpoint>"; export CosmosKey="<primary-key>"
+```
+
+> **Security note:** Never commit your Cosmos DB primary key or connection string to source control. Prefer environment variables (or RBAC). The `.gitignore` already excludes `appsettings.development.json` and `local.settings.json`, which remain supported as a fallback.
 
 Happy coding with Azure Cosmos DB and these powerful design patterns!
 

--- a/attribute-array/README.md
+++ b/attribute-array/README.md
@@ -171,7 +171,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
     az login
     ```
 
-1. Open the attribute-array project and add a new **appsettings.development.json** file with the following contents:
+1. Open the attribute-array project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
     ```json
     {
@@ -187,7 +187,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. From the Keys blade, copy both the **URI** and **PRIMARY KEY** values.
 
-1. Open the attribute-array project and add a new **appsettings.development.json** file with the following contents:
+1. Open the attribute-array project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
     ```json
     {

--- a/attribute-array/source/Program.cs
+++ b/attribute-array/source/Program.cs
@@ -10,7 +10,8 @@ using Database = Microsoft.Azure.Cosmos.Database;
 
 IConfigurationBuilder configuration = new ConfigurationBuilder()
     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-    .AddJsonFile($"appsettings.development.json", optional: true);
+    .AddJsonFile($"appsettings.development.json", optional: true)
+    .AddEnvironmentVariables();
 
 Cosmos? config = configuration
     .Build()

--- a/data-binning/README.md
+++ b/data-binning/README.md
@@ -170,7 +170,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
     az login
     ```
 
-1. Open the data-binning project and add a new **appsettings.development.json** file with the following contents:
+1. Open the data-binning project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
     ```json
     {
@@ -186,7 +186,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. From the Keys blade, copy both the **URI** and **PRIMARY KEY** values.
 
-1. Open the data-binning project and add a new **appsettings.development.json** file with the following contents:
+1. Open the data-binning project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
     ```json
     {

--- a/data-binning/source/DataBinning.csproj
+++ b/data-binning/source/DataBinning.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/data-binning/source/Program.cs
+++ b/data-binning/source/Program.cs
@@ -66,7 +66,8 @@ namespace DataBinning
 
             var configuration = new ConfigurationBuilder()
                  .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                 .AddJsonFile($"appsettings.development.json", optional: true);
+                 .AddJsonFile($"appsettings.development.json", optional: true)
+                 .AddEnvironmentVariables();
 
             var config = configuration.Build();
 

--- a/distributed-counter/README.md
+++ b/distributed-counter/README.md
@@ -106,7 +106,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
     az login
     ```
 
-1. Open the **Visualizer** project and add a new **appsettings.development.json** file with the following contents:
+1. Open the **Visualizer** project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
     ```json
     {
@@ -120,7 +120,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
 
 Next move to the other project.
 
-1. Open the **ConsumerApp** project and add a new **appsettings.development.json** file with the same contents.
+1. Open the **ConsumerApp** project and set the same values as environment variables, or add an **appsettings.development.json** file with the same contents.
 
 ### Option 2: Key-based authentication (local emulator fallback)
 
@@ -128,7 +128,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. From the Keys blade, copy both the **URI** and **PRIMARY KEY** values.
 
-1. Open the **Visualizer** project and add a new **appsettings.development.json** file with the following contents:
+1. Open the **Visualizer** project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
     ```json
     {
@@ -139,7 +139,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
     }
     ```
 
-1. Open the **ConsumerApp** project and add a new **appsettings.development.json** file with the same contents.
+1. Open the **ConsumerApp** project and set the same values as environment variables, or add an **appsettings.development.json** file with the same contents.
 
 > **Note:** Never commit `appsettings.development.json` with real key values. The `.gitignore` already excludes `appsettings.development.json`.
 

--- a/distributed-counter/source/ConsumerApp/DistributedCounterConsumerApp.csproj
+++ b/distributed-counter/source/ConsumerApp/DistributedCounterConsumerApp.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Spectre.Console" Version="0.57.2" />
   </ItemGroup>

--- a/distributed-counter/source/ConsumerApp/Program.cs
+++ b/distributed-counter/source/ConsumerApp/Program.cs
@@ -17,7 +17,8 @@ namespace Cosmos_Patterns_DistributedCounter
 
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.development.json", optional: true);
+                .AddJsonFile($"appsettings.development.json", optional: true)
+                .AddEnvironmentVariables();
 
             var config = configuration.Build();
 

--- a/distributed-lock/README.md
+++ b/distributed-lock/README.md
@@ -84,7 +84,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
     az login
     ```
 
-1. Open the distributed-lock project and add a new **appsettings.development.json** file with the following contents:
+1. Open the distributed-lock project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
 ```json
 {
@@ -103,7 +103,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. From the Keys blade, copy both the **URI** and **PRIMARY KEY** values.
 
-1. Open the distributed-lock project and add a new **appsettings.development.json** file with the following contents:
+1. Open the distributed-lock project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
 ```json
 {

--- a/distributed-lock/source/GlobalLock.csproj
+++ b/distributed-lock/source/GlobalLock.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/distributed-lock/source/Program.cs
+++ b/distributed-lock/source/Program.cs
@@ -16,7 +16,8 @@ namespace Cosmos_Patterns_GlobalLock
 
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.development.json", optional: true);
+                .AddJsonFile($"appsettings.development.json", optional: true)
+                .AddEnvironmentVariables();
 
             var config = configuration.Build();
 

--- a/document-versioning/README.md
+++ b/document-versioning/README.md
@@ -114,7 +114,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
 
 ## Prepare the web app configuration
 
-1. Open the website project and add a new **appsettings.development.json** file with the following contents:
+1. Open the website project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
 ```json
 {
@@ -136,7 +136,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. From the Keys blade, copy both the **URI** and **PRIMARY KEY** values.
 
-1. Open the website project and add a new **appsettings.development.json** file with the following contents:
+1. Open the website project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
 ```json
 {

--- a/document-versioning/source/website/Program.cs
+++ b/document-versioning/source/website/Program.cs
@@ -37,7 +37,6 @@ static class ProgramExtensions
         builder.Configuration.AddJsonFile("appsettings.json");
         builder.Configuration.AddJsonFile($"appsettings.development.json", optional: true);
         builder.Configuration.AddEnvironmentVariables();
-        builder.Configuration.AddUserSecrets<Options.CosmosDb>();
 
         builder.Services.AddOptions<Options.CosmosDb>()
             .Bind(builder.Configuration.GetSection(nameof(Options.CosmosDb)));

--- a/materialized-view/README.md
+++ b/materialized-view/README.md
@@ -144,7 +144,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
 
 ## Prepare the data generator configuration
 
-1. Navigate to the data-generator folder, open the project and add a new **appsettings.development.json** file with the following contents:
+1. Navigate to the data-generator folder, open the project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
   ```json
   {

--- a/materialized-view/source/data-generator/Program.cs
+++ b/materialized-view/source/data-generator/Program.cs
@@ -20,7 +20,8 @@ namespace MaterializedViews
 
             IConfigurationBuilder configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            .AddJsonFile($"appsettings.development.json", optional: true);
+            .AddJsonFile($"appsettings.development.json", optional: true)
+            .AddEnvironmentVariables();
 
             Cosmos? config = configuration
                 .Build()

--- a/preallocation/README.md
+++ b/preallocation/README.md
@@ -258,7 +258,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
     az login
     ```
 
-1. Open the project and add a new **appsettings.development.json** file with the following contents:
+1. Open the project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
   ```json
   {
@@ -277,7 +277,7 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. From the Keys blade, copy both the **URI** and **PRIMARY KEY** values.
 
-1. Open the project and add a new **appsettings.development.json** file with the following contents:
+1. Open the project and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
   ```json
   {

--- a/preallocation/source/Preallocation.csproj
+++ b/preallocation/source/Preallocation.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/preallocation/source/Program.cs
+++ b/preallocation/source/Program.cs
@@ -17,7 +17,8 @@ namespace Preallocation
         {
             IConfigurationBuilder configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            .AddJsonFile("appsettings.development.json", optional: true);
+            .AddJsonFile("appsettings.development.json", optional: true)
+            .AddEnvironmentVariables();
 
             _config = configuration
                 .Build()

--- a/schema-versioning/README.md
+++ b/schema-versioning/README.md
@@ -213,7 +213,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
     az login
     ```
 
-1. In Codespace or locally, open the data-generator folder and add a new **appsettings.development.json** file with the following contents:
+1. In Codespace or locally, open the data-generator folder and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
   ```json
   {
@@ -226,7 +226,7 @@ Keyless authentication using `DefaultAzureCredential` is the recommended approac
 
 1. Replace `<endpoint>` with the **URI** value copied from the Keys blade.
 
-1. Open the website folder and add a new **appsettings.development.json** file with the following contents:
+1. Open the website folder and set these values as environment variables (recommended — see [Configuration and authentication](../README.md#configuration-and-authentication)), or add an **appsettings.development.json** file with the following contents:
 
   ```json
   {

--- a/schema-versioning/source/data-generator/Program.cs
+++ b/schema-versioning/source/data-generator/Program.cs
@@ -17,7 +17,8 @@ namespace Versioning
 
             IConfigurationBuilder configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            .AddJsonFile("appsettings.development.json", optional: true);
+            .AddJsonFile("appsettings.development.json", optional: true)
+            .AddEnvironmentVariables();
 
             _config = configuration
                 .Build()

--- a/schema-versioning/source/data-generator/data-generator.csproj
+++ b/schema-versioning/source/data-generator/data-generator.csproj
@@ -13,6 +13,7 @@
 	<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
 	<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 	<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/schema-versioning/source/website/Program.cs
+++ b/schema-versioning/source/website/Program.cs
@@ -29,6 +29,7 @@ static class ProgramExtensions
     {
         builder.Configuration.AddJsonFile("appsettings.json");
         builder.Configuration.AddJsonFile($"appsettings.development.json", optional: true);
+        builder.Configuration.AddEnvironmentVariables();
 
         builder.Services.AddOptions<CosmosDb>()
             .Bind(builder.Configuration.GetSection(nameof(CosmosDb)));


### PR DESCRIPTION
Addresses #42 by making **environment variables** the recommended way to supply the Cosmos DB endpoint/key for local development, while keeping ppsettings.development.json as a fallback. This keeps credentials out of plaintext files and works cleanly with the emulator, containers, and CI.

## Why not full user-secrets / RBAC-only?
The samples must keep working against the **emulator** (key-based), so key support stays. Environment variables layer on top of the existing JSON config, so nothing breaks and the keyless `DefaultAzureCredential` path is unchanged.

## Code changes
- Add `.AddEnvironmentVariables()` to every console/data-generator config builder and to `schema-versioning/website` (others already had it). Added the `Microsoft.Extensions.Configuration.EnvironmentVariables` package where it was missing.
- Remove a broken `AddUserSecrets<CosmosDb>()` call in `document-versioning/website` — there is no `UserSecretsId`, so that call throws at startup.

## Variable names (follow each project's existing binding)
- Console / data-generator: `CosmosUri`, `CosmosKey` (some also `CosmosDatabase` / `CosmosContainer`)
- Websites (section-bound): `CosmosDb__CosmosUri`, `CosmosDb__CosmosKey`
- Functions samples already use `local.settings.json` values (env-var native)

## Docs
- Root README: auth section rewritten to document env vars first, with the exact variable names and an `appsettings.development.json` fallback.
- Each pattern README recommends env vars and links to the root README, keeping the appsettings example as an alternative.

## Verification
All affected projects build on .NET 10. Verified env-var binding at runtime: with an **empty** `appsettings.json`, a console sample connected to the endpoint supplied **only** via `\` (keyless), confirming the environment variable is consumed.

Fixes #42