### PR TITLE
Add optional azd deployment for event-sourcing (pilot for #68)

### DIFF
--- a/event-sourcing/README.md
+++ b/event-sourcing/README.md
@@ -227,6 +227,49 @@ Open a new terminal and run the included Console App (Program.cs) which generate
 dotnet run
 ```
 
+## (Optional) Deploy to Azure with `azd`
+
+> **This step is optional.** Everything above runs locally against the Azure Cosmos DB emulator or your own account — you do **not** need to deploy anything to Azure to learn this pattern. This section is only for when you *also* want to see the sample running in Azure with a secure, keyless (Microsoft Entra ID + managed identity) deployment.
+
+This sample includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template that provisions the infrastructure and deploys the function with a single command. It is intentionally minimal and cheap:
+
+- A **Flex Consumption** Function App — scales to zero, so you only pay when it actually runs.
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The Function App reaches both Cosmos DB and its storage account using its **managed identity** — no keys or connection strings are stored anywhere.
+
+The deployment files (`azure.yaml` and the `infra/` folder) are self-contained; they have no effect on running the sample locally.
+
+### Prerequisites
+
+- [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd)
+- An Azure subscription
+
+### Deploy
+
+From the `event-sourcing` folder:
+
+```bash
+azd up
+```
+
+`azd` prompts for an environment name, subscription, and location, then provisions the resources and deploys the function. When it finishes it prints the function's URL, for example `https://func-xxxxx.azurewebsites.net/`.
+
+Send a cart event to the deployed function (replace the URL with the one `azd` printed):
+
+```bash
+curl -X POST "https://func-xxxxx.azurewebsites.net/api/EventSourcing" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"11111111-1111-1111-1111-111111111111","CartId":"22222222-2222-2222-2222-222222222222","SessionId":"33333333-3333-3333-3333-333333333333","UserId":1,"EventType":"cart_created","ProductsInCart":[]}'
+```
+
+### Clean up
+
+To delete every resource the deployment created:
+
+```bash
+azd down
+```
+
 ## Querying the event source data
 
 Once you have run [the demo](./code/setup.md) which generates data, you can run queries directly against the event source container by using **Data Explorer** in the Azure Portal.

--- a/event-sourcing/azure.yaml
+++ b/event-sourcing/azure.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-event-sourcing
+metadata:
+  template: cosmos-db-design-patterns-event-sourcing
+services:
+  eventsourcing:
+    project: ./source
+    language: dotnet
+    host: function

--- a/event-sourcing/infra/main.bicep
+++ b/event-sourcing/infra/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the event-sourcing sample: a serverless, keyless Azure Cosmos DB account and a Consumption Function App that writes to it via managed identity.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_EVENTSOURCING_NAME string = resources.outputs.functionAppName

--- a/event-sourcing/infra/main.parameters.json
+++ b/event-sourcing/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/event-sourcing/infra/resources.bicep
+++ b/event-sourcing/infra/resources.bicep
@@ -1,0 +1,168 @@
+metadata description = 'Resources for the event-sourcing sample: a Flex Consumption Function App (system-assigned identity, keyless) that writes to a serverless, keyless Azure Cosmos DB account. Uses managed identity for both Cosmos and storage so no keys or connection strings are stored.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access (local runs) and blob access (to publish the app package).')
+param principalId string = ''
+
+// Well-known built-in role definition IDs.
+var storageBlobDataOwnerRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+var deploymentContainerName = 'deployments'
+
+// Storage account required by the Functions runtime. Shared-key auth is disabled;
+// access is via managed identity only.
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'st${resourceToken}'
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+  }
+
+  resource blobServices 'blobServices' = {
+    name: 'default'
+
+    resource deploymentContainer 'containers' = {
+      name: deploymentContainerName
+    }
+  }
+}
+
+// Flex Consumption plan: scales to zero, pay-per-execution (cheap).
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'plan-${resourceToken}'
+  location: location
+  tags: tags
+  kind: 'functionapp'
+  sku: {
+    name: 'FC1'
+    tier: 'FlexConsumption'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: 'func-${resourceToken}'
+  location: location
+  // azd uses this tag to deploy the matching service's code to this resource.
+  tags: union(tags, { 'azd-service-name': 'eventsourcing' })
+  kind: 'functionapp,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storage.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'SystemAssignedIdentity'
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        maximumInstanceCount: 40
+        instanceMemoryMB: 2048
+      }
+      runtime: {
+        name: 'dotnet-isolated'
+        version: '10.0'
+      }
+    }
+    siteConfig: {
+      minTlsVersion: '1.2'
+      appSettings: [
+        // Identity-based storage for the Functions runtime (no keys).
+        {
+          name: 'AzureWebJobsStorage__accountName'
+          value: storage.name
+        }
+        // Keyless Cosmos DB access via the app's system-assigned managed identity.
+        // The endpoint is derived from the account name to avoid a dependency cycle
+        // (the Cosmos account is granted access to this app's identity).
+        {
+          name: 'CosmosDBConnection__accountEndpoint'
+          value: 'https://cosmos-${resourceToken}.documents.azure.com:443/'
+        }
+        {
+          name: 'CosmosDBConnection__credential'
+          value: 'managedidentity'
+        }
+      ]
+    }
+  }
+}
+
+// The Function App's identity needs blob data access for the runtime and deployment container.
+resource functionStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storage
+  name: guid(storage.id, functionApp.id, storageBlobDataOwnerRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataOwnerRoleId)
+    principalId: functionApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// The deploying user needs blob access to upload the application package (shared key is disabled).
+resource userStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(principalId)) {
+  scope: storage
+  name: guid(storage.id, principalId, storageBlobDataContributorRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: principalId
+    principalType: 'User'
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database/container pre-created and
+// data-plane access granted to the function's identity (and the deploying user).
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'EventSourcingDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'EventSourcingDB'
+        name: 'CartEvents'
+        partitionKey: '/CartId'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ functionApp.identity.principalId ]
+      : [ functionApp.identity.principalId, principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed Function App name.')
+output functionAppName string = functionApp.name

--- a/infra/core/secure-cosmos.bicep
+++ b/infra/core/secure-cosmos.bicep
@@ -1,0 +1,102 @@
+metadata description = 'Shared secure Azure Cosmos DB for NoSQL account used by the design-pattern samples. Serverless, local (key) authentication disabled, with pre-created databases/containers and data-plane RBAC for the supplied principals. Plain Bicep (no external modules) so it stays small and easy to read.'
+
+@description('Required. Name of the Cosmos DB account.')
+param name string
+
+@description('Optional. Location for the account.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags to apply to the account.')
+param tags object = {}
+
+@description('Optional. SQL databases to pre-create. Shape: [{ name: string }].')
+param databases array = []
+
+@description('Optional. Containers to pre-create. Shape: [{ databaseName: string, name: string, partitionKey: string }]. Pre-creating them means the app identity only needs data-plane item access, not permission to create databases/containers.')
+param containers array = []
+
+@description('Optional. Principal IDs (managed identities and/or users) to grant the built-in Cosmos DB Data Contributor data-plane role.')
+param dataContributorPrincipalIds array = []
+
+// Cosmos DB built-in "Data Contributor" data-plane role definition (fixed, well-known id).
+var dataContributorRoleId = '00000000-0000-0000-0000-000000000002'
+
+resource account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
+  name: name
+  location: location
+  tags: tags
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    // Force Microsoft Entra ID (RBAC) authentication; the account has no usable keys.
+    disableLocalAuth: true
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+      }
+    ]
+    // Serverless keeps the samples cheap (pay per request, no provisioned throughput).
+    capabilities: [
+      {
+        name: 'EnableServerless'
+      }
+    ]
+  }
+}
+
+resource sqlDatabases 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-11-15' = [
+  for db in databases: {
+    parent: account
+    name: db.name
+    properties: {
+      resource: {
+        id: db.name
+      }
+    }
+  }
+]
+
+resource containersResource 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = [
+  for container in containers: {
+    name: '${account.name}/${container.databaseName}/${container.name}'
+    properties: {
+      resource: {
+        id: container.name
+        partitionKey: {
+          paths: [
+            container.partitionKey
+          ]
+          kind: 'Hash'
+        }
+      }
+    }
+    dependsOn: [
+      sqlDatabases
+    ]
+  }
+]
+
+resource dataContributorAssignments 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-11-15' = [
+  for principalId in dataContributorPrincipalIds: {
+    parent: account
+    name: guid(account.id, principalId, dataContributorRoleId)
+    properties: {
+      roleDefinitionId: '${account.id}/sqlRoleDefinitions/${dataContributorRoleId}'
+      principalId: principalId
+      scope: account.id
+    }
+  }
+]
+
+@description('The document endpoint of the Cosmos DB account.')
+output endpoint string = account.properties.documentEndpoint
+
+@description('The name of the Cosmos DB account.')
+output name string = account.name
+
+@description('The resource ID of the Cosmos DB account.')
+output resourceId string = account.id


### PR DESCRIPTION
A **pilot** for #68 that adds an **optional**, minimal `azd` + Bicep deployment to the event-sourcing sample. Running the sample locally is completely unchanged — the deployment files have no effect unless you run `azd up`, and this is called out clearly in the README.

## What it deploys (intentionally minimal & cheap — no AVM, no Log Analytics/App Insights)
- **Flex Consumption** Function App (`dotnet-isolated` 10) that scales to zero — pay only when it runs.
- **Serverless** Cosmos DB with `disableLocalAuth=true`; the database/container are pre-created so the app identity only needs data-plane *item* access (avoids the database-create RBAC gap).
- **Fully keyless:** the Function reaches both Cosmos DB and its storage account via its **system-assigned managed identity** — no keys or connection strings stored anywhere. (This also satisfies "no local auth" governance policies.)

## Reusable core
`infra/core/secure-cosmos.bicep` is a small, plain-Bicep module (serverless, `disableLocalAuth`, pre-created databases/containers, data-plane RBAC) that the other pattern archetypes (web app, console) can share as this rolls out.

## Verified end to end
`azd up` → provisioned + deployed in ~6 min → POST to the live function → **HTTP 200** → document **read back from the deployed Cosmos account**, written by the Function's managed identity (keyless) → `azd down` cleaned everything up.

## Scope
This is the **event-sourcing (Functions) archetype** pilot. The **web** (App Service) and **console (Cosmos-only)** archetypes will follow in separate PRs, reusing the shared core module. Not marked as closing #68 for that reason.