### PR TITLE
Add optional azd deployment for document-versioning (web archetype, #68)

### DIFF
--- a/document-versioning/README.md
+++ b/document-versioning/README.md
@@ -158,6 +158,8 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 ## Run the demo
 
+> This sample can be run **two ways**: *all-local* (this section — your machine or Codespaces against the Cosmos DB emulator or your own account) or *all-Azure* (deployed and running in Azure — see [Deploy and run in Azure](#optional-deploy-and-run-in-azure-with-azd) below). You don't need Azure to learn the pattern.
+
 1. In Codespaces or locally, navigate to the `website` folder, start the website with:
 
 ```bash
@@ -204,6 +206,32 @@ You can also query the `HistoricalOrderStatus` container for that order number a
 In this example, the previously shown document was fulfilled. Notice in the Azure Data Explorer results that the `DocumentVersion` property is now a part of the document in `CurrentOrderStatus`.
 
 ![Screenshot of Azure Data Explorer querying HistoricalOrderStatus with the OrderId and CustomerId from the previous example. The Status is now Fulfilled. The DocumentVersion property appears at the top of the document and is now at 2. There are 2 results in the results list.](images/newly-submitted-order-fulfilled-with-history.png)
+
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above are the **all-local** way to run the sample. If you'd rather run the **all-Azure** way — the sample deployed and running in Azure — this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd up`.
+
+It provisions and deploys, intentionally minimal and cheap:
+
+- An **App Service** web app (Basic **B1** with "Always On", so the in-app Change Feed processor keeps running).
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The web app reaches Cosmos DB **keyless**, via a **user-assigned managed identity** — no keys or connection strings are stored anywhere.
+
+### Deploy
+
+From the `document-versioning` folder:
+
+```bash
+azd up
+```
+
+`azd` prompts for an environment name, subscription, and location, then provisions the resources and deploys the site. When it finishes it prints the site URL — open it and create/fulfill orders exactly as in the local walkthrough above.
+
+### Clean up
+
+```bash
+azd down
+```
 
 ## Summary
 

--- a/document-versioning/azure.yaml
+++ b/document-versioning/azure.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-document-versioning
+metadata:
+  template: cosmos-db-design-patterns-document-versioning
+services:
+  web:
+    project: ./source/website
+    language: dotnet
+    host: appservice

--- a/document-versioning/infra/main.bicep
+++ b/document-versioning/infra/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the document-versioning sample: a serverless, keyless Azure Cosmos DB account and an App Service web app that reads/writes and runs a Change Feed processor against it via managed identity.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_WEB_URL string = resources.outputs.webUrl

--- a/document-versioning/infra/main.parameters.json
+++ b/document-versioning/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/document-versioning/infra/resources.bicep
+++ b/document-versioning/infra/resources.bicep
@@ -1,0 +1,116 @@
+metadata description = 'Resources for the document-versioning sample: an App Service web app that reads/writes and runs a Change Feed processor against a serverless, keyless Azure Cosmos DB account. The app authenticates to Cosmos with a user-assigned managed identity (used deterministically via AZURE_CLIENT_ID).'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+param principalId string = ''
+
+// User-assigned managed identity that the web app uses to talk to Cosmos DB.
+// Created first so its principal is known up front (no dependency cycle) and so the
+// app can select it unambiguously via AZURE_CLIENT_ID.
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'id-${resourceToken}'
+  location: location
+  tags: tags
+}
+
+// Basic (B1) plan so the web app can enable "Always On" (required for the in-app
+// Change Feed processor background service). Still an inexpensive tier.
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'plan-${resourceToken}'
+  location: location
+  tags: tags
+  kind: 'linux'
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource web 'Microsoft.Web/sites@2023-12-01' = {
+  name: 'web-${resourceToken}'
+  location: location
+  // azd uses this tag to deploy the matching service's code to this resource.
+  tags: union(tags, { 'azd-service-name': 'web' })
+  kind: 'app,linux'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identity.id}': {}
+    }
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'DOTNETCORE|10.0'
+      minTlsVersion: '1.2'
+      // Keep the app warm so the Change Feed background service keeps running.
+      alwaysOn: true
+      appSettings: [
+        // Keyless Cosmos DB access. CosmosKey is left unset, so the app uses
+        // DefaultAzureCredential; AZURE_CLIENT_ID makes it use the user-assigned identity.
+        {
+          name: 'AZURE_CLIENT_ID'
+          value: identity.properties.clientId
+        }
+        {
+          name: 'CosmosDb__CosmosUri'
+          value: cosmos.outputs.endpoint
+        }
+      ]
+    }
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database/containers pre-created and
+// data-plane access granted to the app's user-assigned identity (and the deploying user).
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'DocumentVersionDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'DocumentVersionDB'
+        name: 'CurrentOrderStatus'
+        partitionKey: '/CustomerId'
+      }
+      {
+        databaseName: 'DocumentVersionDB'
+        name: 'HistoricalOrderStatus'
+        partitionKey: '/CustomerId'
+      }
+      {
+        databaseName: 'DocumentVersionDB'
+        name: 'leases'
+        partitionKey: '/id'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ identity.properties.principalId ]
+      : [ identity.properties.principalId, principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed web app URL.')
+output webUrl string = 'https://${web.properties.defaultHostName}'

--- a/document-versioning/source/website/Services/ArchiveService.cs
+++ b/document-versioning/source/website/Services/ArchiveService.cs
@@ -12,6 +12,11 @@ namespace Services
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            // Ensure the database/containers exist (retried) before starting the processor.
+            // Runs in the background service, so the web app can start and serve requests
+            // even while Cosmos DB access is still being established at startup.
+            await cosmosDb.InitializeAsync(stoppingToken);
+
             changeFeedProcessor = await StartChangeFeedProcessorAsync(cosmosDb.OrderContainer, cosmosDb.LeasesContainer);
         }
 

--- a/document-versioning/source/website/Services/CosmosDb.cs
+++ b/document-versioning/source/website/Services/CosmosDb.cs
@@ -6,13 +6,16 @@ namespace Services
     public class CosmosDb
     {
         private readonly CosmosClient client;
-        private Container? orderContainer;
-        private Container? historyContainer;
-        private Container? leasesContainer;
+        private readonly string databaseName;
+        private readonly string currentOrderContainerName;
+        private readonly string historicalOrderContainerName;
+        private readonly string partitionKey;
 
-        public Container OrderContainer => orderContainer ?? throw new InvalidOperationException("OrderContainer is not initialized.");
-        public Container HistoryContainer => historyContainer ?? throw new InvalidOperationException("HistoryContainer is not initialized.");
-        public Container LeasesContainer => leasesContainer ?? throw new InvalidOperationException("LeasesContainer is not initialized.");
+        // Container handles are lightweight proxies (no network call), so they are safe to
+        // create up front. They become usable once the database/containers exist.
+        public Container OrderContainer { get; }
+        public Container HistoryContainer { get; }
+        public Container LeasesContainer { get; }
 
         public CosmosDb(string cosmosUri, string? cosmosKey, string database, string currentOrderContainer, string historicalOrderContainer, string partitionKey)
         {
@@ -22,29 +25,56 @@ namespace Services
                 ? new CosmosClient(accountEndpoint: cosmosUri, tokenCredential: new DefaultAzureCredential())
                 : new CosmosClient(accountEndpoint: cosmosUri, authKeyOrResourceToken: cosmosKey);
 
-            InitializeAsync(database, currentOrderContainer, historicalOrderContainer, partitionKey).Wait();
+            databaseName = database;
+            currentOrderContainerName = currentOrderContainer;
+            historicalOrderContainerName = historicalOrderContainer;
+            this.partitionKey = partitionKey;
+
+            OrderContainer = client.GetContainer(database, currentOrderContainer);
+            HistoryContainer = client.GetContainer(database, historicalOrderContainer);
+            LeasesContainer = client.GetContainer(database, "leases");
         }
 
-        private async Task InitializeAsync(string databaseName, string currentOrderContainerName, string historicalOrderContainerName, string partitionKey)
+        /// <summary>
+        /// Ensures the database and containers exist. Called in the background at startup rather
+        /// than synchronously in the constructor, so the app does not block (or crash) while
+        /// waiting on Cosmos DB. The call is retried to tolerate transient startup conditions such
+        /// as managed-identity token/role-assignment propagation when deployed to Azure.
+        /// When the account already has the database/containers (for example, provisioned by the
+        /// azd/Bicep deployment) these calls simply read and return.
+        /// </summary>
+        public async Task InitializeAsync(CancellationToken cancellationToken = default)
         {
-            Database database = await client.CreateDatabaseIfNotExistsAsync(databaseName);
+            const int maxAttempts = 30;
+            for (int attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    Database database = await client.CreateDatabaseIfNotExistsAsync(databaseName, cancellationToken: cancellationToken);
 
-            orderContainer = await database.CreateContainerIfNotExistsAsync(
-                id: currentOrderContainerName,
-                partitionKeyPath: partitionKey
-            );
+                    await database.CreateContainerIfNotExistsAsync(
+                        id: currentOrderContainerName,
+                        partitionKeyPath: partitionKey,
+                        cancellationToken: cancellationToken);
 
-            historyContainer = await database.CreateContainerIfNotExistsAsync(
-                id: historicalOrderContainerName,
-                partitionKeyPath: partitionKey
-            );
+                    await database.CreateContainerIfNotExistsAsync(
+                        id: historicalOrderContainerName,
+                        partitionKeyPath: partitionKey,
+                        cancellationToken: cancellationToken);
 
-            leasesContainer = await database.CreateContainerIfNotExistsAsync(
-                id: "leases",
-                partitionKeyPath: "/id"
-            );
+                    await database.CreateContainerIfNotExistsAsync(
+                        id: "leases",
+                        partitionKeyPath: "/id",
+                        cancellationToken: cancellationToken);
+
+                    return;
+                }
+                catch (Exception) when (attempt < maxAttempts && !cancellationToken.IsCancellationRequested)
+                {
+                    // Back off (capped) and retry; covers transient auth/connectivity at startup.
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Min(attempt * 3, 30)), cancellationToken);
+                }
+            }
         }
-
-        
     }
 }

--- a/document-versioning/source/website/website.csproj
+++ b/document-versioning/source/website/website.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -13,8 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="appsettings.*.json">
+    <Content Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <!-- Keep dev settings available for local runs, but NEVER include them (or any
+         secrets they contain) in a published / deployed build. -->
+    <Content Update="appsettings.development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 


### PR DESCRIPTION
Adds the **web archetype** for #68: an **optional**, minimal `azd` + Bicep deployment for the document-versioning web sample. Running locally is unchanged — the `infra/` files only matter if you run `azd up` — and the README now documents both flavors (all-local vs all-Azure).

## Also fixes a real (security-relevant) bug this surfaced
The csproj published `appsettings.*.json`, so a developer's local, **git-ignored** `appsettings.development.json` — including any Cosmos **key** they put in it for local runs (as the sample instructs) — was **included in the deployed package**. The deployed app then used **key auth** against a keyless account and failed. Now `appsettings.development.json` is kept for local runs but **never published**.

> The same `appsettings.*.json` publish pattern exists in several other sample csproj files; those can be fixed the same way in follow-ups.

## What it deploys (minimal & cheap — no AVM/Log Analytics/App Insights)
- **App Service B1** with *Always On* (needed for the in-app Change Feed processor background service).
- **Serverless** Cosmos DB with `disableLocalAuth=true`; database/containers pre-created so the app identity only needs data-plane *item* access.
- **Keyless** via a **user-assigned managed identity**, selected deterministically with `AZURE_CLIENT_ID`.

## Resilience improvement
The app's Cosmos startup was a blocking `InitializeAsync().Wait()` in the constructor, which crash-loops if Cosmos isn't immediately reachable/authorized (e.g. RBAC still propagating on first deploy). It's now **non-blocking and retried**, so the app starts and self-heals.

## Verified end to end
`azd up` → created orders through the app (keyless writes via managed identity) → the **Change Feed processor archived them to the history container** (keyless) → `azd down`.

Addresses #68 (web archetype).