### PR TITLE
Don't publish local appsettings.development.json (avoid deploying dev secrets)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,6 +358,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
-/document-versioning/source/website/appsettings.Development.json
-/schema-versioning/source/website/appsettings.Development.json
 /document-versioning/source/source.sln

--- a/attribute-array/source/AttributeArray.csproj
+++ b/attribute-array/source/AttributeArray.csproj
@@ -7,17 +7,13 @@
     <RootNamespace>AttributeArray</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="appsettings.*.json">
+    <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <None Remove="appsettings.Development.json" />
-    <Content Include="appsettings.json">
+    </None>
+    <None Update="appsettings.development.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />

--- a/distributed-counter/source/ConsumerApp/DistributedCounterConsumerApp.csproj
+++ b/distributed-counter/source/ConsumerApp/DistributedCounterConsumerApp.csproj
@@ -8,9 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.*.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/distributed-counter/source/Visualizer/DistributedCounterDashboard.csproj
+++ b/distributed-counter/source/Visualizer/DistributedCounterDashboard.csproj
@@ -11,8 +11,12 @@
     <ProjectReference Include="..\Counter\CosmosDistributedCounter.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Update="appsettings.*.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 </Project>

--- a/distributed-lock/source/GlobalLock.csproj
+++ b/distributed-lock/source/GlobalLock.csproj
@@ -23,14 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="appsettings.development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 

--- a/materialized-view/source/data-generator/data-generator.csproj
+++ b/materialized-view/source/data-generator/data-generator.csproj
@@ -19,11 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 

--- a/preallocation/source/Preallocation.csproj
+++ b/preallocation/source/Preallocation.csproj
@@ -18,8 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.*.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 

--- a/schema-versioning/source/data-generator/data-generator.csproj
+++ b/schema-versioning/source/data-generator/data-generator.csproj
@@ -19,8 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.*.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 

--- a/schema-versioning/source/website/website.csproj
+++ b/schema-versioning/source/website/website.csproj
@@ -16,8 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="appsettings.*.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes a repo-wide hygiene/security issue: several csproj files copied `appsettings.*.json` into the publish output, so a developer's local, **git-ignored** `appsettings.development.json` — including any Cosmos **key** they put in it for local runs (as the sample READMEs instruct) — was **bundled into the published / azd-deployed package**. A deployed app would then use that leaked key.

## Change
Every affected project now:
- keeps `appsettings.development.json` available for **local runs** (copied to the build output), but
- sets `CopyToPublishDirectory=Never` so it is **never** included in a published or `azd` build.

The committed `appsettings.json` files (empty placeholder values) are unchanged. Also drops two redundant `.gitignore` entries already covered by the `appsettings.*.json` rule.

## Projects updated
attribute-array, distributed-counter (ConsumerApp + Visualizer), distributed-lock, materialized-view (data-generator), preallocation, schema-versioning (data-generator + website).

*(document-versioning's website got the same fix in #84; the Functions samples already exclude `local.settings.json` from publish.)*

## Verified
Published a console project and a web project with a local `appsettings.development.json` present — only `appsettings.json` appears in the publish output; the dev file (and its secret) is excluded. All 8 projects build clean.