### PR TITLE
Add azd deployment for schema-versioning (Addresses #68)

### DIFF
--- a/infra/core/web-app.bicep
+++ b/infra/core/web-app.bicep
@@ -1,0 +1,82 @@
+metadata description = 'Shared App Service web app for the design-pattern samples: a Linux App Service with a user-assigned managed identity used (deterministically, via AZURE_CLIENT_ID) for keyless access to Azure Cosmos DB. Plain Bicep, intentionally small and reusable across the web samples.'
+
+@description('Required. Name of the web app.')
+param name string
+
+@description('Optional. Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags to apply. Include an "azd-service-name" tag so azd deploys the app code here.')
+param tags object = {}
+
+@description('Optional. Linux runtime stack.')
+param linuxFxVersion string = 'DOTNETCORE|10.0'
+
+@description('Optional. Keep the app always running. Required when the app hosts an in-app background service such as a Change Feed processor.')
+param alwaysOn bool = true
+
+@description('Optional. App settings (name/value pairs). AZURE_CLIENT_ID (for the managed identity) is added automatically.')
+param appSettings array = []
+
+// User-assigned identity the app uses for keyless Cosmos DB access. Created here so the
+// same identity can be granted the Cosmos data-plane role and selected via AZURE_CLIENT_ID.
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'id-${name}'
+  location: location
+  tags: tags
+}
+
+// Basic (B1) plan — inexpensive and supports "Always On".
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'plan-${name}'
+  location: location
+  tags: tags
+  kind: 'linux'
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource site 'Microsoft.Web/sites@2023-12-01' = {
+  name: name
+  location: location
+  tags: tags
+  kind: 'app,linux'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identity.id}': {}
+    }
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: linuxFxVersion
+      minTlsVersion: '1.2'
+      alwaysOn: alwaysOn
+      appSettings: concat(appSettings, [
+        {
+          name: 'AZURE_CLIENT_ID'
+          value: identity.properties.clientId
+        }
+      ])
+    }
+  }
+}
+
+@description('Principal ID of the managed identity (grant it the Cosmos data-plane role).')
+output identityPrincipalId string = identity.properties.principalId
+
+@description('Client ID of the managed identity.')
+output identityClientId string = identity.properties.clientId
+
+@description('The web app name.')
+output name string = site.name
+
+@description('The web app URL.')
+output url string = 'https://${site.properties.defaultHostName}'

--- a/schema-versioning/README.md
+++ b/schema-versioning/README.md
@@ -154,6 +154,8 @@ public class Cart
 
 ## Try this implementation
 
+> This sample can be run **two ways**: *all-local* (this section — your machine or Codespaces against the Cosmos DB emulator or your own account) or *all-Azure* (deployed and running in Azure — see [Deploy and run in Azure](#optional-deploy-and-run-in-azure-with-azd) below). You don't need Azure to learn the pattern.
+
 You can run this sample locally or in GitHub Codespaces:
 
 ### GitHub Codespaces
@@ -322,6 +324,32 @@ Navigate to the URL displayed in the output. In the example below, the URL is sh
 The output will show a variety of randomly generated carts and include the schema version when populated. When a cart contains no special items, the Special Order Notes field will not appear in the cart table.
 
 ![Screenshot of the schema-versioned carts demo. The first cart shows 2 items with the fields Product Name and Quantity. The second cart shows 3 items with the fields for Schema Version, Product Name, Quantity, and Special Order Notes. The third cart shows 1 item with the fields for Schema Version, Product Name, Quantity, and Special Order Notes. The fourth cart shows 1 item with the fields for Schema Version, Product Name, and Quantity.](./images/schema-versioned-carts-website.png)
+
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above are the **all-local** way to run the sample. If you'd rather run the **all-Azure** way — the sample deployed and running in Azure — this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd up`.
+
+It provisions and deploys, intentionally minimal and cheap:
+
+- An **App Service** web app (Basic **B1**).
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The web app reaches Cosmos DB **keyless**, via a **user-assigned managed identity** — no keys or connection strings are stored anywhere.
+
+### Deploy
+
+From the `schema-versioning` folder:
+
+```bash
+azd up
+```
+
+`azd` prompts for an environment name, subscription, and location, then provisions the resources and deploys the site. When it finishes it prints the site URL — open it to see the schema-versioned carts exactly as in the local walkthrough above.
+
+### Clean up
+
+```bash
+azd down
+```
 
 ## Summary
 

--- a/schema-versioning/azure.yaml
+++ b/schema-versioning/azure.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-schema-versioning
+metadata:
+  template: cosmos-db-design-patterns-schema-versioning
+services:
+  web:
+    project: ./source/website
+    language: dotnet
+    host: appservice

--- a/schema-versioning/infra/main.bicep
+++ b/schema-versioning/infra/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the schema-versioning sample: a serverless, keyless Azure Cosmos DB account and an App Service web app that reads/writes it via managed identity.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_WEB_URL string = resources.outputs.webUrl

--- a/schema-versioning/infra/main.parameters.json
+++ b/schema-versioning/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/schema-versioning/infra/resources.bicep
+++ b/schema-versioning/infra/resources.bicep
@@ -1,0 +1,64 @@
+metadata description = 'Resources for the schema-versioning sample: an App Service web app (keyless, via managed identity) over a serverless, keyless Azure Cosmos DB account. Reuses the shared web-app and secure-cosmos modules.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+param principalId string = ''
+
+// App Service web app + user-assigned identity (shared module). Plain CRUD app, so it
+// does not need "Always On". The Cosmos endpoint is derived from the account name to
+// avoid a dependency cycle (the Cosmos account is granted access to this app's identity).
+module web '../../infra/core/web-app.bicep' = {
+  name: 'web-app'
+  params: {
+    name: 'web-${resourceToken}'
+    location: location
+    tags: union(tags, { 'azd-service-name': 'web' })
+    alwaysOn: false
+    appSettings: [
+      {
+        name: 'CosmosDb__CosmosUri'
+        value: 'https://cosmos-${resourceToken}.documents.azure.com:443/'
+      }
+    ]
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database/container pre-created and
+// data-plane access granted to the web app's identity (and the deploying user).
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'SchemaVersionDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'SchemaVersionDB'
+        name: 'ShoppingCart'
+        partitionKey: '/id'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ web.outputs.identityPrincipalId ]
+      : [ web.outputs.identityPrincipalId, principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed web app URL.')
+output webUrl string = web.outputs.url

--- a/schema-versioning/source/website/Services/CosmosDbService.cs
+++ b/schema-versioning/source/website/Services/CosmosDbService.cs
@@ -8,7 +8,7 @@ namespace Versioning.Services
         private readonly CosmosClient _client;
         private readonly Container _container;
 
-        public Container CartsContainer => _container ?? throw new InvalidOperationException("Carts Container is not initialized.");
+        public Container CartsContainer => _container;
 
         public CosmosDbService(string cosmosUri, string? cosmosKey, string databaseName, string containerName, string partitionKeyPath)
         {
@@ -18,19 +18,34 @@ namespace Versioning.Services
                 ? new CosmosClient(accountEndpoint: cosmosUri, tokenCredential: new DefaultAzureCredential())
                 : new CosmosClient(accountEndpoint: cosmosUri, authKeyOrResourceToken: cosmosKey);
 
-_container = InitializeAsync(databaseName, containerName, partitionKeyPath).GetAwaiter().GetResult();
+            // Container handle is a lightweight proxy (no network call); usable once the
+            // database/container exist.
+            _container = _client.GetContainer(databaseName, containerName);
+
+            // Ensure the database/container exist in the background rather than blocking (or
+            // crashing) the app at startup while waiting on Cosmos DB. The call is retried to
+            // tolerate transient startup conditions such as managed-identity role propagation
+            // when deployed to Azure. When the account already has them (for example, provisioned
+            // by the azd/Bicep deployment) these calls simply read and return.
+            _ = EnsureCreatedAsync(databaseName, containerName, partitionKeyPath);
         }
 
-        private async Task<Container> InitializeAsync(string databaseName, string containerName, string partitionKeyPath)
+        private async Task EnsureCreatedAsync(string databaseName, string containerName, string partitionKeyPath)
         {
-            Database database = await _client.CreateDatabaseIfNotExistsAsync(id: databaseName);
-
-            Container container = await database.CreateContainerIfNotExistsAsync(
-                id: containerName,
-                partitionKeyPath: partitionKeyPath
-            );
-
-            return container;
+            const int maxAttempts = 30;
+            for (int attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    Database database = await _client.CreateDatabaseIfNotExistsAsync(id: databaseName);
+                    await database.CreateContainerIfNotExistsAsync(id: containerName, partitionKeyPath: partitionKeyPath);
+                    return;
+                }
+                catch when (attempt < maxAttempts)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Min(attempt * 3, 30)));
+                }
+            }
         }
     }
 }

--- a/schema-versioning/source/website/appsettings.json
+++ b/schema-versioning/source/website/appsettings.json
@@ -12,15 +12,5 @@
     "DatabaseName": "SchemaVersionDB",
     "ContainerName": "ShoppingCart",
     "PartitionKeyPath": "/id"
-  },
-  "Kestrel": {
-    "Endpoints": {
-      "Http": {
-        "Url": "http://*:5000"
-      }
-    },
-    "RedirectToHttps": {
-      "Enabled": false
-    }
   }
 }


### PR DESCRIPTION
Addresses #68. Adds the optional **all-Azure** flavor for the schema-versioning web sample via an Azure Developer CLI (`azd`) template. Running locally is unchanged; the deployment files have no effect unless you run `azd up`.

## What this adds
- **`infra/core/web-app.bicep`** (new shared module): App Service **B1** + user-assigned managed identity, reusable across the web archetypes.
- **`schema-versioning/infra/`** + **`azure.yaml`**: composes `web-app` with the existing `secure-cosmos` module — serverless Cosmos, `disableLocalAuth`, pre-created `SchemaVersionDB`/`ShoppingCart`, and a data-plane role assignment so the app reaches Cosmos **keyless**.

## Fixes found along the way
- **Removed hardcoded `Kestrel` `:5000` from `appsettings.json`.** It's dead config locally (local dev uses `launchSettings.json`) but took effect once published, forcing the app onto `:5000` while Linux App Service probes the platform port → **503/hang**. Removing it lets the app honor the platform port like every standard sample. Verified deployed app now logs `Now listening on http://[::]:8080`.
- **`CosmosDbService` startup resilience**: non-blocking `GetContainer` proxy + background retried init so the app doesn't crash-loop during managed-identity RBAC propagation on cold start.

## Validation (real, deployed)
Provisioned to a temp env, then:
- Steady **HTTP 200** after warmup.
- Homepage runs a Cosmos query on load — a **200** proves the managed identity's **keyless** read works; **zero** 401/403/5202 in app logs.
- Torn down afterward.

Kept intentionally minimal and cheap (B1 + serverless Cosmos; no Log Analytics/App Insights/AVM), consistent with this repo being a developer pattern sample, not production architecture.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>