### PR TITLE
Add azd deployment for console-app patterns (Addresses #68)

### DIFF
--- a/attribute-array/README.md
+++ b/attribute-array/README.md
@@ -268,6 +268,46 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
     Notice the remarkable difference in query construction. It is very clean. It also concisely returns the product name, size and count in stock for that size.
 
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run the sample **all-local** (against the Azure Cosmos DB emulator or your own account). If you'd rather run it against a dedicated, **keyless** Azure Cosmos DB account in Azure, this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd provision`.
+
+Because this sample is a **console app**, there is no service hosted in Azure — `azd` only provisions the data store, intentionally minimal and cheap:
+
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The sample's `AttributeArrayDB` database and `ArrayAttributes` container, pre-created.
+- A data-plane role assignment granting **you** (the deploying user) keyless access, so you can run the console app locally against it.
+
+### Provision
+
+From the `attribute-array` folder:
+
+```bash
+azd provision
+```
+
+When it finishes, point the app at the new account and run it locally — keyless, using your `az login` credentials:
+
+```bash
+# bash / zsh
+export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
+cd source && dotnet run
+```
+
+```powershell
+# PowerShell
+$env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
+cd source; dotnet run
+```
+
+Leave `CosmosKey` empty — with only `CosmosUri` set, the app authenticates keyless via `DefaultAzureCredential`.
+
+### Clean up
+
+```bash
+azd down
+```
+
 ## Summary
 
 By applying this pattern to similar properties in data model, you can reduce and simplify your indexing, simplify your queries, making them less prone to future bugs, and improve performance and cost.

--- a/attribute-array/azure.yaml
+++ b/attribute-array/azure.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-attribute-array
+metadata:
+  template: cosmos-db-design-patterns-attribute-array
+# This is a console sample: azd only provisions the (keyless, serverless) Cosmos DB
+# account and grants the deploying user data-plane access. There is no service to
+# deploy; run the console app locally with `dotnet run` after `azd provision`.

--- a/attribute-array/infra/main.bicep
+++ b/attribute-array/infra/main.bicep
@@ -1,0 +1,38 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the attribute-array sample: a serverless, keyless Azure Cosmos DB account. The sample is a console app, so there is no compute to deploy; the deploying user is granted data-plane access to run it locally via managed identity / Azure CLI.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint

--- a/attribute-array/infra/main.parameters.json
+++ b/attribute-array/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/attribute-array/infra/resources.bicep
+++ b/attribute-array/infra/resources.bicep
@@ -1,0 +1,38 @@
+metadata description = 'Resources for the attribute-array console sample: a serverless, keyless Azure Cosmos DB account with the sample database/container pre-created and data-plane access granted to the deploying user. Pre-creating the container means the app identity only needs data-plane item access, not permission to create databases/containers.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+param principalId string = ''
+
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'AttributeArrayDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'AttributeArrayDB'
+        name: 'ArrayAttributes'
+        partitionKey: '/productId'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId) ? [] : [ principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint

--- a/data-binning/README.md
+++ b/data-binning/README.md
@@ -253,6 +253,46 @@ GROUP BY c.DeviceId
 
 Note: The generated data will likely have many values considered anomalies. You can test out different filters to create your own rules.
 
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run the sample **all-local** (against the Azure Cosmos DB emulator or your own account). If you'd rather run it against a dedicated, **keyless** Azure Cosmos DB account in Azure, this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd provision`.
+
+Because this sample is a **console app**, there is no service hosted in Azure — `azd` only provisions the data store, intentionally minimal and cheap:
+
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The sample's `DataBinningDB` database and `DataBinning` container, pre-created.
+- A data-plane role assignment granting **you** (the deploying user) keyless access, so you can run the console app locally against it.
+
+### Provision
+
+From the `data-binning` folder:
+
+```bash
+azd provision
+```
+
+When it finishes, point the app at the new account and run it locally — keyless, using your `az login` credentials:
+
+```bash
+# bash / zsh
+export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
+cd source && dotnet run
+```
+
+```powershell
+# PowerShell
+$env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
+cd source; dotnet run
+```
+
+Leave `CosmosKey` empty — with only `CosmosUri` set, the app authenticates keyless via `DefaultAzureCredential`.
+
+### Clean up
+
+```bash
+azd down
+```
+
 ## Summary
 
 When modeling data for any application it's important to consider how the data will be used. NoSQL databases provide the ability to model data in a hierarchy within a JSON document. Applying the data binning pattern allows you to collect and aggregate data for how it is most often used. This provides efficency at multiple levels and simplifies design. This example we demonstrated provides a simple pattern for optimization. This pattern can be expanded upon and combined with other patterns to optimize even further or in different ways to give you the best performance and efficiency for your solutions.

--- a/data-binning/azure.yaml
+++ b/data-binning/azure.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-data-binning
+metadata:
+  template: cosmos-db-design-patterns-data-binning
+# This is a console sample: azd only provisions the (keyless, serverless) Cosmos DB
+# account and grants the deploying user data-plane access. There is no service to
+# deploy; run the console app locally with `dotnet run` after `azd provision`.

--- a/data-binning/infra/main.bicep
+++ b/data-binning/infra/main.bicep
@@ -1,0 +1,38 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the data-binning sample: a serverless, keyless Azure Cosmos DB account. The sample is a console app, so there is no compute to deploy; the deploying user is granted data-plane access to run it locally via managed identity / Azure CLI.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint

--- a/data-binning/infra/main.parameters.json
+++ b/data-binning/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/data-binning/infra/resources.bicep
+++ b/data-binning/infra/resources.bicep
@@ -1,0 +1,38 @@
+metadata description = 'Resources for the data-binning console sample: a serverless, keyless Azure Cosmos DB account with the sample database/container pre-created and data-plane access granted to the deploying user. Pre-creating the container means the app identity only needs data-plane item access, not permission to create databases/containers.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+param principalId string = ''
+
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'DataBinningDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'DataBinningDB'
+        name: 'DataBinning'
+        partitionKey: '/DeviceId'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId) ? [] : [ principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint

--- a/distributed-lock/README.md
+++ b/distributed-lock/README.md
@@ -138,6 +138,48 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 1. When prompted, enter the values for the lock name and the default TTL
 
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run the sample **all-local** (against the Azure Cosmos DB emulator or your own account). If you'd rather run it against a dedicated, **keyless** Azure Cosmos DB account in Azure, this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd provision`.
+
+Because this sample is a **console app**, there is no service hosted in Azure — `azd` only provisions the data store, intentionally minimal and cheap:
+
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The sample's `LockDB` database and `Locks` container (created with a 60-second TTL so leases auto-expire, matching the app), pre-created.
+- A data-plane role assignment granting **you** (the deploying user) keyless access, so you can run the console app locally against it.
+
+### Provision
+
+From the `distributed-lock` folder:
+
+```bash
+azd provision
+```
+
+When it finishes, point the app at the new account and run it locally — keyless, using your `az login` credentials:
+
+```bash
+# bash / zsh
+export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
+cd source && dotnet run
+```
+
+```powershell
+# PowerShell
+$env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
+cd source; dotnet run
+```
+
+Leave `CosmosKey` empty — with only `CosmosUri` set, the app authenticates keyless via `DefaultAzureCredential`.
+
+> **Consistency note:** This template provisions a single-region **serverless** account, which uses **Session** consistency. The lock's correctness — mutual exclusion and monotonically increasing fence tokens — comes from optimistic concurrency (a unique-id insert plus `ETag`-checked patches), so it holds under any consistency level, not just Strong. For a multi-region *production* lock you would instead use provisioned throughput with **Strong** (or **Bounded staleness**) consistency; serverless accounts are single-region only.
+
+### Clean up
+
+```bash
+azd down
+```
+
 ## Summary
 
 Azure Cosmos DB makes implementing a global lock fairly simple by utilizing the `TTL` and 'ETag' features.

--- a/distributed-lock/azure.yaml
+++ b/distributed-lock/azure.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-distributed-lock
+metadata:
+  template: cosmos-db-design-patterns-distributed-lock
+# This is a console sample: azd only provisions the (keyless, serverless) Cosmos DB
+# account and grants the deploying user data-plane access. There is no service to
+# deploy; run the console app locally with `dotnet run` after `azd provision`.

--- a/distributed-lock/infra/main.bicep
+++ b/distributed-lock/infra/main.bicep
@@ -1,0 +1,38 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the distributed-lock sample: a serverless, keyless Azure Cosmos DB account. The sample is a console app, so there is no compute to deploy; the deploying user is granted data-plane access to run it locally via managed identity / Azure CLI.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint

--- a/distributed-lock/infra/main.parameters.json
+++ b/distributed-lock/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/distributed-lock/infra/resources.bicep
+++ b/distributed-lock/infra/resources.bicep
@@ -1,0 +1,39 @@
+metadata description = 'Resources for the distributed-lock console sample: a serverless, keyless Azure Cosmos DB account with the sample database/container pre-created and data-plane access granted to the deploying user. The Locks container is created with a 60-second TTL so leases auto-expire, matching the app. The account uses the shared module default (Session consistency); lock safety comes from optimistic concurrency (ETag + unique-id conditional writes), not the consistency level.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+param principalId string = ''
+
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'LockDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'LockDB'
+        name: 'Locks'
+        partitionKey: '/id'
+        defaultTtl: 60
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId) ? [] : [ principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint

--- a/infra/core/secure-cosmos.bicep
+++ b/infra/core/secure-cosmos.bicep
@@ -12,7 +12,7 @@ param tags object = {}
 @description('Optional. SQL databases to pre-create. Shape: [{ name: string }].')
 param databases array = []
 
-@description('Optional. Containers to pre-create. Shape: [{ databaseName: string, name: string, partitionKey: string }]. Pre-creating them means the app identity only needs data-plane item access, not permission to create databases/containers.')
+@description('Optional. Containers to pre-create. Shape: [{ databaseName: string, name: string, partitionKey: string, defaultTtl: int? }]. Pre-creating them means the app identity only needs data-plane item access, not permission to create databases/containers. Set defaultTtl (seconds, or -1 for no expiry) to enable time-to-live on the container.')
 param containers array = []
 
 @description('Optional. Principal IDs (managed identities and/or users) to grant the built-in Cosmos DB Data Contributor data-plane role.')
@@ -64,15 +64,21 @@ resource containersResource 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
   for container in containers: {
     name: '${account.name}/${container.databaseName}/${container.name}'
     properties: {
-      resource: {
-        id: container.name
-        partitionKey: {
-          paths: [
-            container.partitionKey
-          ]
-          kind: 'Hash'
-        }
-      }
+      // Merge in defaultTtl only when supplied, so containers without a TTL don't
+      // emit an explicit null (which Cosmos rejects). defaultTtl is in seconds,
+      // or -1 for enabled with no default expiry.
+      resource: union(
+        {
+          id: container.name
+          partitionKey: {
+            paths: [
+              container.partitionKey
+            ]
+            kind: 'Hash'
+          }
+        },
+        container.?defaultTtl != null ? { defaultTtl: container.defaultTtl } : {}
+      )
     }
     dependsOn: [
       sqlDatabases

--- a/preallocation/README.md
+++ b/preallocation/README.md
@@ -322,6 +322,46 @@ or from Visual Studio, press **F5** to start the application.
 
 1. In the `Hotel.cs` view the queries for each method. Note the simpler design for queries and application logic using Preallocation  versus when not using it.
 
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run the sample **all-local** (against the Azure Cosmos DB emulator or your own account). If you'd rather run it against a dedicated, **keyless** Azure Cosmos DB account in Azure, this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd provision`.
+
+Because this sample is a **console app**, there is no service hosted in Azure — `azd` only provisions the data store, intentionally minimal and cheap:
+
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
+- The sample's `PreallocationDB` database and both comparison containers (`WithPreallocation` and `WithoutPreallocation`), pre-created.
+- A data-plane role assignment granting **you** (the deploying user) keyless access, so you can run the console app locally against it.
+
+### Provision
+
+From the `preallocation` folder:
+
+```bash
+azd provision
+```
+
+When it finishes, point the app at the new account and run it locally — keyless, using your `az login` credentials:
+
+```bash
+# bash / zsh
+export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
+cd source && dotnet run
+```
+
+```powershell
+# PowerShell
+$env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
+cd source; dotnet run
+```
+
+Leave `CosmosKey` empty — with only `CosmosUri` set, the app authenticates keyless via `DefaultAzureCredential`.
+
+### Clean up
+
+```bash
+azd down
+```
+
 ## Summary
 
 Pre-allocation allows for a much simpler design for queries and logic versus other approaches. It can often yield faster reponse times as well. However it can come at the cost of a larger document in storage and RU charge given the pre-allocation of the data.

--- a/preallocation/azure.yaml
+++ b/preallocation/azure.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-preallocation
+metadata:
+  template: cosmos-db-design-patterns-preallocation
+# This is a console sample: azd only provisions the (keyless, serverless) Cosmos DB
+# account and grants the deploying user data-plane access. There is no service to
+# deploy; run the console app locally with `dotnet run` after `azd provision`.

--- a/preallocation/infra/main.bicep
+++ b/preallocation/infra/main.bicep
@@ -1,0 +1,38 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the preallocation sample: a serverless, keyless Azure Cosmos DB account. The sample is a console app, so there is no compute to deploy; the deploying user is granted data-plane access to run it locally via managed identity / Azure CLI.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint

--- a/preallocation/infra/main.parameters.json
+++ b/preallocation/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/preallocation/infra/resources.bicep
+++ b/preallocation/infra/resources.bicep
@@ -1,0 +1,43 @@
+metadata description = 'Resources for the preallocation console sample: a serverless, keyless Azure Cosmos DB account with the sample database and both comparison containers pre-created, and data-plane access granted to the deploying user. Pre-creating the containers means the app identity only needs data-plane item access, not permission to create databases/containers.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+param principalId string = ''
+
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'PreallocationDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'PreallocationDB'
+        name: 'WithPreallocation'
+        partitionKey: '/hotelId'
+      }
+      {
+        databaseName: 'PreallocationDB'
+        name: 'WithoutPreallocation'
+        partitionKey: '/hotelId'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId) ? [] : [ principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint


### PR DESCRIPTION
Addresses #68. Adds the optional **all-Azure** flavor to the four **Cosmos-only console** samples via an Azure Developer CLI (`azd`) template: **attribute-array**, **data-binning**, **distributed-lock**, and **preallocation**. Running locally is unchanged; the deployment files have no effect unless you run `azd provision`.

## What this adds
Each pattern gets `azure.yaml` + `infra/` that provision, intentionally minimal and cheap:
- A **serverless** Azure Cosmos DB account with local (key) auth **disabled**.
- The sample's database and container(s), **pre-created**.
- A data-plane role assignment granting **the deploying user** keyless access.

Because these are **console apps**, there is no compute hosted in Azure. The README documents `azd provision`, then running the app locally against the provisioned account with `DefaultAzureCredential` (your `az login`).

## Shared module change
- `infra/core/secure-cosmos.bicep` now supports an optional per-container `defaultTtl`, merged via `union` only when supplied (so containers without a TTL don't emit an explicit `null`, which Cosmos rejects). distributed-lock uses it to pre-create `Locks` with the 60-second TTL the app relies on for lease expiry.

## distributed-lock consistency
The legacy `azuredeploy.json` used **Strong** consistency (defensive, for a hypothetical multi-region deployment). This template uses the shared default — single-region **serverless**, which is **Session** consistency — because:
- Lock safety (mutual exclusion + monotonic fence tokens) comes from **optimistic concurrency** — a unique-id insert plus `ETag`-checked patches — which holds under **any** consistency level.
- Serverless accounts are **single-region only**, so the multi-region rationale for Strong doesn't apply to this sample account.

This is documented in the distributed-lock README.

## Validation (real, deployed)
Provisioned each pattern to a temp env and ran keyless end-to-end, then tore everything down:
- **attribute-array** — app connected keyless and created its DB/container.
- **data-binning** — ran fully keyless; wrote binned sensor events.
- **distributed-lock** — ran fully keyless; observed correct mutual exclusion and monotonic fence tokens across three contending threads; TTL=60 confirmed on the pre-created container.
- **preallocation** — both containers verified; keyless write/read/delete roundtrip confirmed.

Consistent with this repo being a developer pattern sample, not production architecture (no Log Analytics/App Insights/AVM).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>