### PR TITLE
Add azd deployment for distributed-counter (Addresses #68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ All of these design patterns are built to run from a single Serverless Azure Cos
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgithub.com%2FAzureCosmosDB%2Fdesign-patterns%2Ftree%2Fmain%2Fazuredeploy.json)
 
+#### Two ways to run each sample
+
+You can run these samples **two ways**:
+
+- **All-local** — run the sample on your machine or in GitHub Codespaces against the Azure Cosmos DB emulator or your own account (such as the shared account from the button above). This is all you need to learn the patterns; no Azure deployment is required.
+- **All-Azure** — most samples include an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template that provisions a dedicated, **keyless** (Microsoft Entra ID / managed identity) set of Azure resources for that one sample — and, for the web samples, deploys the app. Look for the **"(Optional) Deploy and run in Azure with `azd`"** section in the sample's `README.md`.
+
+The `azd` templates are intentionally minimal and inexpensive — this repository teaches Cosmos DB **design patterns**, not production or enterprise architecture — and each is fully removed with `azd down` when you're finished.
+
 #### Configuration and authentication
 
 Each sample reads its Azure Cosmos DB endpoint (and, optionally, an account key) from configuration. The **recommended way to supply these values for local development is environment variables** — they keep secrets out of the source tree and work well with the emulator, containers, and CI. Every sample still also reads `appsettings.development.json` (git-ignored) as a file-based fallback if you prefer it.

--- a/distributed-counter/README.md
+++ b/distributed-counter/README.md
@@ -156,6 +156,8 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 ## Run the demo locally
 
+> This sample can be run **two ways**: *all-local* (this section — the Visualizer and ConsumerApp on your machine or in Codespaces, against the emulator or your own account) or *all-Azure* (the Visualizer hosted in Azure with the ConsumerApp run locally — see [Deploy and run in Azure](#optional-deploy-and-run-in-azure-with-azd) below). You don't need Azure to learn the pattern.
+
 1. Open a terminal and run the web application. The web application opens in a new browser window.
 
     ```bash
@@ -207,6 +209,52 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
     ![Screenshot of the dynamic graph updated with distributed counter values.](media/distributed-counter-graph.png)
 
 1. When all the counters drop to zero in the chart, return to the consumer app and press `ctrl-c` to stop the app.
+
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run everything **all-local**. If you'd rather run the **all-Azure** way — the Visualizer dashboard hosted in Azure over a keyless Cosmos DB account — this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd up`.
+
+It provisions and deploys, intentionally minimal and cheap:
+
+- An **App Service** web app (Basic **B1**) hosting the **Visualizer** dashboard.
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**, with the `CounterDB` database and `Counters` container pre-created.
+- The Visualizer reaches Cosmos DB **keyless**, via a **user-assigned managed identity** — no keys or connection strings are stored anywhere. The deploying user is also granted data access so you can run the **ConsumerApp** locally against the same account.
+
+The **ConsumerApp** is a console driver, so it is not hosted in Azure — you run it locally against the provisioned account, exactly as in the local walkthrough above.
+
+### Deploy
+
+From the `distributed-counter` folder:
+
+```bash
+azd up
+```
+
+`azd` prompts for an environment name, subscription, and location, then provisions the resources and deploys the Visualizer. When it finishes it prints the site URL.
+
+1. Open the Visualizer URL and create a new counter, then copy its **Counter ID**.
+1. Run the ConsumerApp locally against the same account — keyless, using your `az login` credentials:
+
+    ```bash
+    # bash / zsh
+    export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
+    cd source/ConsumerApp && dotnet run
+    ```
+
+    ```powershell
+    # PowerShell
+    $env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
+    cd source/ConsumerApp; dotnet run
+    ```
+
+    Leave `CosmosKey` empty — with only `CosmosUri` set, the app authenticates keyless via `DefaultAzureCredential`.
+1. Watch the counter values change in the Visualizer.
+
+### Clean up
+
+```bash
+azd down
+```
 
 ## Summary
 

--- a/distributed-counter/azure.yaml
+++ b/distributed-counter/azure.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-distributed-counter
+metadata:
+  template: cosmos-db-design-patterns-distributed-counter
+# azd deploys the Visualizer web dashboard to App Service. The ConsumerApp is a local
+# driver you run with `dotnet run` against the same provisioned (keyless) Cosmos account.
+services:
+  web:
+    project: ./source/Visualizer
+    language: dotnet
+    host: appservice

--- a/distributed-counter/infra/main.bicep
+++ b/distributed-counter/infra/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the distributed-counter sample: the Visualizer web dashboard on App Service (keyless, via managed identity) over a serverless, keyless Azure Cosmos DB account. The ConsumerApp console driver is run locally against the same account.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs (e.g. the ConsumerApp).')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_WEB_URL string = resources.outputs.webUrl

--- a/distributed-counter/infra/main.parameters.json
+++ b/distributed-counter/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/distributed-counter/infra/resources.bicep
+++ b/distributed-counter/infra/resources.bicep
@@ -1,0 +1,74 @@
+metadata description = 'Resources for the distributed-counter sample: the Visualizer App Service web app (keyless, via managed identity) over a serverless, keyless Azure Cosmos DB account. Reuses the shared web-app and secure-cosmos modules. The ConsumerApp console driver runs locally against the same account.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs (e.g. the ConsumerApp).')
+param principalId string = ''
+
+// Visualizer web dashboard + user-assigned identity (shared module). It polls Cosmos
+// on demand, so it does not need "Always On". The Cosmos endpoint is derived from the
+// account name to avoid a dependency cycle (the Cosmos account is granted access to this
+// app's identity).
+module web '../../infra/core/web-app.bicep' = {
+  name: 'web-app'
+  params: {
+    name: 'web-${resourceToken}'
+    location: location
+    tags: union(tags, { 'azd-service-name': 'web' })
+    alwaysOn: false
+    appSettings: [
+      {
+        name: 'CosmosUri'
+        value: 'https://cosmos-${resourceToken}.documents.azure.com:443/'
+      }
+      {
+        name: 'CosmosDatabase'
+        value: 'CounterDB'
+      }
+      {
+        name: 'CosmosContainer'
+        value: 'Counters'
+      }
+    ]
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database/container pre-created and
+// data-plane access granted to the web app's identity (and the deploying user, who runs
+// the ConsumerApp locally).
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'CounterDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'CounterDB'
+        name: 'Counters'
+        partitionKey: '/pk'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ web.outputs.identityPrincipalId ]
+      : [ web.outputs.identityPrincipalId, principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed Visualizer web app URL.')
+output webUrl string = web.outputs.url


### PR DESCRIPTION
Addresses #68. Adds the optional **all-Azure** flavor for the distributed-counter sample via an Azure Developer CLI (`azd`) template, and documents the two flavors globally in the root README. Running locally is unchanged; the deployment files have no effect unless you run `azd up`.

## What this adds
- Deploys the **Visualizer** Blazor dashboard to **App Service** (reuses the shared `infra/core/web-app.bicep` — B1, no Always On since it polls Cosmos on demand) over a **serverless, keyless** Cosmos DB account (shared `secure-cosmos.bicep`; `CounterDB`/`Counters` pre-created, pk `/pk`).
- The **ConsumerApp** console driver is **not** hosted in Azure — it's run locally against the same provisioned account. The deploying user is granted the Cosmos data-plane role so the local ConsumerApp works keyless.
- Per-sample README gets a two-flavors note and an `azd` deploy/run/clean-up section.
- Root README documents the **two ways to run** (all-local vs all-Azure) globally, and notes the `azd` templates are intentionally minimal/inexpensive — this repo teaches Cosmos DB **design patterns**, not production/enterprise architecture.

## Validation (real, deployed)
Provisioned and deployed to a temp env, then:
- The hosted **Visualizer** returned **HTTP 200** with live Blazor rendering — its keyless startup init against Cosmos (via the user-assigned managed identity) succeeded.
- A keyless **write/read/delete roundtrip** against `CounterDB`/`Counters` confirmed the **local ConsumerApp** data path (`DefaultAzureCredential` / `az login`).
- Torn down afterward.

## Notes
- **materialized-view** is intentionally **not** included here — its change-feed/GSI approach overlaps open issue #81, so its `azd` template is deferred until that lands. With this PR, every other pattern has an `azd` template.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>