### PR TITLE
Add azd deployment for materialized-view; migrate function to isolated worker

### DIFF
--- a/materialized-view/README.md
+++ b/materialized-view/README.md
@@ -191,7 +191,7 @@ Use the `__accountEndpoint` suffix to configure the Cosmos DB trigger/binding wi
       "IsEncrypted": false,
       "Values": {
         "AzureWebJobsStorage": "UseDevelopmentStorage=false",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "CosmosDBConnection__accountEndpoint": "<endpoint>"
       }
     }
@@ -210,7 +210,7 @@ Use the `__accountEndpoint` suffix to configure the Cosmos DB trigger/binding wi
       "IsEncrypted": false,
       "Values": {
         "AzureWebJobsStorage": "UseDevelopmentStorage=false",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "CosmosDBConnection" : "<primary-connection-string>"
       }
     }
@@ -233,6 +233,8 @@ Use the `__accountEndpoint` suffix to configure the Cosmos DB trigger/binding wi
   ```
 
 ## Run the demo locally
+
+> This sample can be run **two ways**: *all-local* (this section — the function and data-generator on your machine or in Codespaces, against the emulator or your own account) or *all-Azure* (the change-feed function deployed to Azure with the data-generator run locally — see [Deploy and run in Azure](#optional-deploy-and-run-in-azure-with-azd) below). You don't need Azure to learn the pattern.
 
 1. Switch to the `function-app` folder. Then start the function with:
 
@@ -295,6 +297,48 @@ Make note of the values under **Query Stats**. These are the stats for the query
 Look at the values under **Query Stats**. For this demo, pay close attention to the **Index lookup time**. In this example, the query was run over the 50 documents only in the **SalesByProduct** container. The index lookup time came back at 0.08 ms.
 
 ![Screenshot of Data Explorer with the query run over the SalesByProduct container. The SalesByProduct container in navigation and the 'Index lookup time' in Query Stats are highlighted.](/materialized-view/images/index-lookup-type-salesbyproduct.png)
+
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run everything **all-local**. If you'd rather run the **all-Azure** way — the change-feed function deployed to Azure over a keyless Cosmos DB account — this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd up`.
+
+It provisions and deploys, intentionally minimal and cheap:
+
+- A **Flex Consumption** Function App (scales to zero) hosting the change-feed processor.
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**, with the `MaterializedViewsDB` database and the `Sales`, `SalesByProduct`, and `leases` containers pre-created.
+- The function reaches Cosmos DB and its storage account **keyless**, via a **system-assigned managed identity** — no keys or connection strings are stored anywhere. The deploying user is also granted data access so you can run the **data-generator** locally against the same account.
+
+The **data-generator** is a console app, so it is not hosted in Azure — you run it locally against the provisioned account, exactly as in the local walkthrough above.
+
+### Deploy
+
+From the `materialized-view` folder:
+
+```bash
+azd up
+```
+
+`azd` prompts for an environment name, subscription, and location, then provisions the resources and deploys the function. When it finishes, run the data-generator locally — keyless, using your `az login` credentials:
+
+```bash
+# bash / zsh
+export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
+cd source/data-generator && dotnet run
+```
+
+```powershell
+# PowerShell
+$env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
+cd source/data-generator; dotnet run
+```
+
+Leave `CosmosKey` empty — with only `CosmosUri` set, the data-generator authenticates keyless via `DefaultAzureCredential`. As it writes to the `Sales` container, the deployed function's Change Feed trigger populates the `SalesByProduct` materialized view. Confirm the results in the Data Explorer for the account.
+
+### Clean up
+
+```bash
+azd down
+```
 
 ## Summary
 

--- a/materialized-view/azure.yaml
+++ b/materialized-view/azure.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-materialized-view
+metadata:
+  template: cosmos-db-design-patterns-materialized-view
+# azd deploys the change-feed function that maintains the materialized view. The
+# data-generator is a local console app you run with `dotnet run` against the same
+# provisioned (keyless) Cosmos account.
+services:
+  materializedview:
+    project: ./source/function-app
+    language: dotnet
+    host: function

--- a/materialized-view/infra/main.bicep
+++ b/materialized-view/infra/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the materialized-view sample: a serverless, keyless Azure Cosmos DB account and a Consumption Function App whose Change Feed trigger maintains the SalesByProduct materialized view via managed identity. The data-generator console app is run locally against the same account.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs (e.g. the data-generator).')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_MATERIALIZEDVIEW_NAME string = resources.outputs.functionAppName

--- a/materialized-view/infra/main.parameters.json
+++ b/materialized-view/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/materialized-view/infra/resources.bicep
+++ b/materialized-view/infra/resources.bicep
@@ -1,0 +1,179 @@
+metadata description = 'Resources for the materialized-view sample: a Flex Consumption Function App (system-assigned identity, keyless) whose Change Feed trigger maintains a materialized view in a serverless, keyless Azure Cosmos DB account. Uses managed identity for both Cosmos and storage so no keys or connection strings are stored.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access (local runs) and blob access (to publish the app package).')
+param principalId string = ''
+
+// Well-known built-in role definition IDs.
+var storageBlobDataOwnerRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+var deploymentContainerName = 'deployments'
+
+// Storage account required by the Functions runtime. Shared-key auth is disabled;
+// access is via managed identity only.
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'st${resourceToken}'
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+  }
+
+  resource blobServices 'blobServices' = {
+    name: 'default'
+
+    resource deploymentContainer 'containers' = {
+      name: deploymentContainerName
+    }
+  }
+}
+
+// Flex Consumption plan: scales to zero, pay-per-execution (cheap).
+resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'plan-${resourceToken}'
+  location: location
+  tags: tags
+  kind: 'functionapp'
+  sku: {
+    name: 'FC1'
+    tier: 'FlexConsumption'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: 'func-${resourceToken}'
+  location: location
+  // azd uses this tag to deploy the matching service's code to this resource.
+  tags: union(tags, { 'azd-service-name': 'materializedview' })
+  kind: 'functionapp,linux'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storage.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'SystemAssignedIdentity'
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        maximumInstanceCount: 40
+        instanceMemoryMB: 2048
+      }
+      runtime: {
+        name: 'dotnet-isolated'
+        version: '10.0'
+      }
+    }
+    siteConfig: {
+      minTlsVersion: '1.2'
+      appSettings: [
+        // Identity-based storage for the Functions runtime (no keys).
+        {
+          name: 'AzureWebJobsStorage__accountName'
+          value: storage.name
+        }
+        // Keyless Cosmos DB access via the app's system-assigned managed identity.
+        // The endpoint is derived from the account name to avoid a dependency cycle
+        // (the Cosmos account is granted access to this app's identity).
+        {
+          name: 'CosmosDBConnection__accountEndpoint'
+          value: 'https://cosmos-${resourceToken}.documents.azure.com:443/'
+        }
+        {
+          name: 'CosmosDBConnection__credential'
+          value: 'managedidentity'
+        }
+      ]
+    }
+  }
+}
+
+// The Function App's identity needs blob data access for the runtime and deployment container.
+resource functionStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storage
+  name: guid(storage.id, functionApp.id, storageBlobDataOwnerRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataOwnerRoleId)
+    principalId: functionApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// The deploying user needs blob access to upload the application package (shared key is disabled).
+resource userStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(principalId)) {
+  scope: storage
+  name: guid(storage.id, principalId, storageBlobDataContributorRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: principalId
+    principalType: 'User'
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database/containers pre-created and
+// data-plane access granted to the function's identity (and the deploying user, who runs
+// the data-generator locally). The Change Feed lease container is pre-created too.
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'MaterializedViewsDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'MaterializedViewsDB'
+        name: 'Sales'
+        partitionKey: '/CustomerId'
+      }
+      {
+        databaseName: 'MaterializedViewsDB'
+        name: 'SalesByProduct'
+        partitionKey: '/Product'
+      }
+      {
+        databaseName: 'MaterializedViewsDB'
+        name: 'leases'
+        partitionKey: '/id'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ functionApp.identity.principalId ]
+      : [ functionApp.identity.principalId, principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed Function App name.')
+output functionAppName string = functionApp.name

--- a/materialized-view/source/function-app/MaterializeViews.csproj
+++ b/materialized-view/source/function-app/MaterializeViews.csproj
@@ -1,12 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>a27195ed-7957-4c62-983d-2c9a3f8e24e1</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.16.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.16.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/materialized-view/source/function-app/MaterializedViewProcessor.cs
+++ b/materialized-view/source/function-app/MaterializedViewProcessor.cs
@@ -1,38 +1,48 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace MaterializedViews
 {
-    public static class MaterializedViewProcessor
+    public class MaterializedViewProcessor
     {
-        [FunctionName("MaterializedViewProcessor")]
-        public static async Task Run(
+        private readonly ILogger<MaterializedViewProcessor> _logger;
+
+        public MaterializedViewProcessor(ILogger<MaterializedViewProcessor> logger)
+        {
+            _logger = logger;
+        }
+
+        [Function(nameof(MaterializedViewProcessor))]
+        [CosmosDBOutput(
+            databaseName: "MaterializedViewsDB",
+            containerName: "SalesByProduct",
+            Connection = "CosmosDBConnection",
+            CreateIfNotExists = true,
+            PartitionKey = "/Product")]
+        public IReadOnlyList<SalesByProduct> Run(
             [CosmosDBTrigger(
                 databaseName: "MaterializedViewsDB",
                 containerName: "Sales",
                 Connection = "CosmosDBConnection",
-                LeaseContainerName = "leases", 
-                CreateLeaseContainerIfNotExists=true)]IReadOnlyList<Sales> input,
-            [CosmosDB(
-                databaseName: "MaterializedViewsDB",
-                containerName: "SalesByProduct", 
-                Connection="CosmosDBConnection", 
-                CreateIfNotExists=true, 
-                PartitionKey="/Product")] IAsyncCollector<SalesByProduct> salesByProduct,
-            ILogger log)
-        {           
-            if (input != null && input.Count > 0)
-            {
-                log.LogInformation("Document count: " + input.Count);
-                
-                foreach (Sales document in input){
-                    
-                    await salesByProduct.AddAsync(new SalesByProduct(document));                                                
+                LeaseContainerName = "leases",
+                CreateLeaseContainerIfNotExists = true)] IReadOnlyList<Sales> input)
+        {
+            var salesByProduct = new List<SalesByProduct>();
 
-                }
+            if (input is null || input.Count == 0)
+            {
+                return salesByProduct;
             }
+
+            _logger.LogInformation("Document count: {Count}", input.Count);
+
+            foreach (Sales document in input)
+            {
+                salesByProduct.Add(new SalesByProduct(document));
+            }
+
+            return salesByProduct;
         }
     }
 }
+

--- a/materialized-view/source/function-app/Program.cs
+++ b/materialized-view/source/function-app/Program.cs
@@ -1,0 +1,14 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureServices(services =>
+    {
+        services.AddApplicationInsightsTelemetryWorkerService();
+        services.ConfigureFunctionsApplicationInsights();
+    })
+    .Build();
+
+host.Run();


### PR DESCRIPTION
Adds the optional **all-Azure** flavor for the materialized-view sample, and migrates its Change Feed function to the **.NET isolated worker** model. Related to #68; does **not** close #81 (see below).

## Function migration (in-process -> isolated)
The function-app used the in-process model (`Microsoft.NET.Sdk.Functions` / `Microsoft.Azure.WebJobs`), which caps at .NET 8 — so it would not actually run on the `net10.0` it targeted — and **cannot** deploy to Flex Consumption. Migrated it to the **isolated worker** (`dotnet-isolated` 10), consistent with event-sourcing:
- New `Program.cs` host builder; `CosmosDBTrigger` + collection `CosmosDBOutput` binding in the isolated style; worker + App Insights worker packages.
- Models already use lowercase `id`, so no System.Text.Json id-casing fix is needed.

## azd template (Flex Consumption, keyless)
- Serverless, keyless Cosmos DB (shared `secure-cosmos.bicep`) with `MaterializedViewsDB` and the `Sales` (`/CustomerId`), `SalesByProduct` (`/Product`) and `leases` (`/id`) containers pre-created.
- **Flex Consumption** Function App with a system-assigned identity — keyless to Cosmos and identity-based storage (no keys/connection strings).
- The **data-generator** console app runs locally against the same account; the deploying user is granted the Cosmos data-plane role.
- README: two-flavors note, an `azd` deploy/run/clean-up section, and `local.settings.json` `FUNCTIONS_WORKER_RUNTIME` updated to `dotnet-isolated`.

## Why this keeps the change-feed implementation (not GSI / #81)
#81 asks to replace this pattern with **Global Secondary Indexes**, gated on *"whether this is supported in the vNext emulator ... a requirement before implementing."* Verified against the official docs:
- The [vNext emulator feature-support table](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator-linux) lists **Change Feed as supported** but does **not** list GSI / materialized views; **Request Units** are *Not yet implemented* and the **Offers endpoint** is a *No-op*.
- [GSI](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-configure-global-secondary-indexes) requires **continuous backups**, an account capability enablement, and **autoscale (provisioned) throughput** — none available in the emulator, and incompatible with the repo's cheap serverless default.

So GSI can't run all-local on the emulator today. Per that prerequisite, this PR keeps the emulator-friendly change-feed implementation and adds its `azd` template. **#81 stays open** for the GSI replacement once the emulator supports it.

## Validation (real, deployed)
Deployed to a temp env: wrote Sales records keyless (the data-generator path) and confirmed the deployed function's Change Feed trigger populated `SalesByProduct` keyless (Widget/Gizmo/Thing counts matched). Torn down afterward.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>