### PR TITLE
Fix distributed lock losing the lock when work exceeds the TTL (#32)

### DIFF
--- a/distributed-lock/README.md
+++ b/distributed-lock/README.md
@@ -37,10 +37,10 @@ By using a distributed global lock, you can coordinate and synchronize the actio
 
 ## Sample implementation
 
-The application creates a Lock based on the Name and Time to Live( TTL) provided by the user. The Lock is created in Azure Cosmos DB and  then can be tracked by multiple geographically distributed worker threads. In this sample  the application creates 3  threads  that continuously try to get  the lock.  The worker thread holds the locks for a random number of milliseconds and then releases it. If the lock is not released with the TTL value, the lock gets released automatically.
+The application creates a Lock based on the Name and Time to Live (TTL) provided by the user. The Lock is created in Azure Cosmos DB and then can be tracked by multiple geographically distributed worker threads. In this sample the application creates 3 threads that continuously try to get the lock. Each worker thread that acquires the lock holds it for a random amount of time — which can be **longer than the lease TTL** — and then releases it. While a worker holds the lock and is still doing work, it automatically **renews the lease** (re-writing it before the TTL elapses) on a background timer, so no other worker can acquire the lock mid-work. If a worker stops or crashes it stops renewing, the lease expires via TTL, and the lock is released automatically — so a stalled worker can never deadlock the lock.
 ![Screenshot showing the Distributed Lock Application running](media/dlock.png)
 
-The TTL feature is used to automatically get rid of a lease object rather than having clients do the work of checking a leasedUntil date.  This takes away one step, but you are still required to check to see if two clients tried to get a lease on the same object at the same time.  This is easily done in Azure Cosmos DB via the 'etag' property on the object.
+The TTL feature is used to automatically get rid of a lease object rather than having clients do the work of checking a leasedUntil date. This takes away one step, but you are still required to check to see if two clients tried to get a lease on the same object at the same time. This is easily done in Azure Cosmos DB via the 'etag' property on the object. The lock document itself is stored with a TTL of `-1` so it never expires (preserving its monotonically increasing fence token); only the lease object carries a TTL, and the lock holder keeps that lease alive by renewing it for as long as it holds the lock.
 
 ## Getting the code
 
@@ -131,6 +131,8 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
     ```
 
 1. When prompted, enter the values for the lock name and the default TTL
+
+   As the three threads compete, notice that only one holds the lock at a time. The holder keeps working even when its work runs longer than the lease TTL — you'll see `Renewed lease ... while work continues` messages and a final `Completed work while still holding lock ... ==> OK`, while the other threads report `FAILED` until the lock is released. The lease is only allowed to expire (freeing the lock) when a holder stops renewing.
 
 ## (Optional) Deploy and run in Azure with `azd`
 

--- a/distributed-lock/source/DistributedLockService.cs
+++ b/distributed-lock/source/DistributedLockService.cs
@@ -190,6 +190,16 @@ namespace CosmosDistributedLock.Services
 
         }
 
+        /// <summary>
+        /// Renews (re-writes) the lease for the given owner, resetting its TTL. Called
+        /// periodically by the lock holder to keep the lease alive while work is in progress,
+        /// so the lease does not expire (and let another worker start) mid-work.
+        /// </summary>
+        public async Task RenewLeaseAsync(string ownerId, int leaseDuration)
+        {
+            await cosmos.CreateUpdateLeaseAsync(ownerId, leaseDuration);
+        }
+
         private async Task<bool> IsValidLeaseAsync(string ownerId)
         {
             Lease lease = await cosmos.ReadLeaseAsync(ownerId);

--- a/distributed-lock/source/LockManager.cs
+++ b/distributed-lock/source/LockManager.cs
@@ -22,6 +22,9 @@ namespace Cosmos_Patterns_GlobalLock
         public string OwnerId { get; set; } //ownerId, ClientId
 
         public long FenceToken { get; set; } //Incrementing token
+
+        [JsonProperty("ttl")]
+        public int Ttl { get; set; } = -1; //Lock persists indefinitely; only the Lease expires (via its own ttl).
     }
 
     public class Lease
@@ -47,6 +50,11 @@ namespace Cosmos_Patterns_GlobalLock
 
         public string leaseOwnerId;
 
+        private readonly Action<string>? onLeaseRenewed;
+        private int leaseDuration;
+        private CancellationTokenSource? renewalCts;
+        private Task? renewalTask;
+
         /// <summary>
         /// This creates a container that has the TTL feature enabled.
         /// </summary>
@@ -55,7 +63,7 @@ namespace Cosmos_Patterns_GlobalLock
         /// <param name="lockContainerName"></param>
         /// <param name="lockName"></param>
         /// <param name="refreshIntervalS"></param>
-        public LockManager( DistributedLockService dls, string lockName, string threadName)
+        public LockManager( DistributedLockService dls, string lockName, string threadName, Action<string>? onLeaseRenewed = null)
         {
             this.dls = dls;
             
@@ -64,6 +72,8 @@ namespace Cosmos_Patterns_GlobalLock
             this.ownerId = Guid.NewGuid().ToString();
 
             this.Name = threadName;
+
+            this.onLeaseRenewed = onLeaseRenewed;
 
         }
 
@@ -75,9 +85,9 @@ namespace Cosmos_Patterns_GlobalLock
         /// <param name="lockContainer"></param>
         /// <param name="lockName"></param>
         /// <returns></returns>
-        static public async Task<LockManager> CreateLockAsync(DistributedLockService dls, string lockName, string threadName)
+        static public async Task<LockManager> CreateLockAsync(DistributedLockService dls, string lockName, string threadName, Action<string>? onLeaseRenewed = null)
         {
-            return new LockManager( dls, lockName, threadName);
+            return new LockManager( dls, lockName, threadName, onLeaseRenewed);
         }
 
         /// <summary>
@@ -89,8 +99,20 @@ namespace Cosmos_Patterns_GlobalLock
         {
             try
             {                
+                this.leaseDuration = leaseDuration;
+
                 var reqStatus= await dls.AcquireLeaseAsync(lockName, ownerId, leaseDuration,existingFenceToken);
                 leaseOwnerId = reqStatus.currentOwner;
+
+                // If we acquired the lock, keep the lease alive by renewing it in the
+                // background until the lock is released or disposed. This prevents the lease
+                // from expiring (and another worker starting) while work is still in progress
+                // and runs longer than the lease duration.
+                if (reqStatus.currentOwner == ownerId && reqStatus.fenceToken > 0)
+                {
+                    StartRenewal();
+                }
+
                 return reqStatus;
             }
             catch (Exception e)
@@ -101,6 +123,8 @@ namespace Cosmos_Patterns_GlobalLock
 
         public async Task<bool> ReleaseLeaseAsync()
         {
+            StopRenewal();
+
             try
             {   
                 if(leaseOwnerId== ownerId)
@@ -143,6 +167,53 @@ namespace Cosmos_Patterns_GlobalLock
 
 
 
+        private void StartRenewal()
+        {
+            renewalCts = new CancellationTokenSource();
+            renewalTask = RenewLeaseLoopAsync(renewalCts.Token);
+        }
+
+        private async Task RenewLeaseLoopAsync(CancellationToken cancellationToken)
+        {
+            // Renew well before the lease expires (at least once per half of the duration).
+            int renewIntervalMs = Math.Max(1, leaseDuration / 2) * 1000;
+
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(renewIntervalMs, cancellationToken);
+                    await dls.RenewLeaseAsync(ownerId, leaseDuration);
+                    onLeaseRenewed?.Invoke($"{Name}: Renewed lease on lock [{lockName}] while work continues.");
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // Expected when the lock is released or disposed.
+            }
+        }
+
+        private void StopRenewal()
+        {
+            if (renewalCts == null)
+                return;
+
+            renewalCts.Cancel();
+
+            try
+            {
+                renewalTask?.Wait();
+            }
+            catch
+            {
+                // Ignore the cancellation exception surfaced by Wait().
+            }
+
+            renewalCts.Dispose();
+            renewalCts = null;
+            renewalTask = null;
+        }
+
         public void Dispose()
         {
             Dispose(true);
@@ -153,7 +224,8 @@ namespace Cosmos_Patterns_GlobalLock
         {
             if (disposing)
             {
-                Task<bool> releaseTask= ReleaseLeaseAsync();
+                StopRenewal();
+                _ = ReleaseLeaseAsync();
             }
 
         }

--- a/distributed-lock/source/LockTest.cs
+++ b/distributed-lock/source/LockTest.cs
@@ -47,7 +47,7 @@ namespace Cosmos_Patterns_GlobalLock
 
             while (this.isActive)
             {                
-                using(var mutex = await LockManager.CreateLockAsync(dls, lockName, threadName))
+                using(var mutex = await LockManager.CreateLockAsync(dls, lockName, threadName, msg => postMessage(new ConsoleMessage(msg, this.color))))
                 {
                     var reqStatus = await mutex.AcquireLeaseAsync(lockDuration, prevFenceToken);
                     var latestFenceToken = reqStatus.fenceToken;
@@ -69,11 +69,16 @@ namespace Cosmos_Patterns_GlobalLock
                         await DoWork(mutex.Name, lockName);
 
 
-                        // checking if lease valid when work is completed
+                        // With automatic lease renewal the lease is still valid even though
+                        // the work took longer than the lease duration.
                         if (!await mutex.HasLeaseAsync(latestFenceToken))
                         {
                             //lock released because of TTL before task completed
                             postMessage(new ConsoleMessage($"{mutex.Name}: Lock [{lockName}] was lost because of TTL of {this.lockDuration} seconds ==> ERROR", this.color));
+                        }
+                        else
+                        {
+                            postMessage(new ConsoleMessage($"{mutex.Name}: Completed work while still holding lock [{lockName}] ==> OK", this.color));
                         }
                         // uncomment if  you want to explicitly want to release the lock. The lock will get released when code exists using block 
                         /*
@@ -99,10 +104,11 @@ namespace Cosmos_Patterns_GlobalLock
 
         private async Task DoWork(string threadName, string lockName)
         {
-            //wait some random time
+            // Intentionally do work that can take LONGER than the lease duration to show that
+            // automatic lease renewal keeps the lock held for the entire time (issue #32).
             Random r = new Random();
-            int delay = r.Next(500, 5000);
-            postMessage(new ConsoleMessage($"{threadName}: Will hold lock [{lockName}] for {delay} milliseconds", this.color));
+            int delay = r.Next(lockDuration * 1000, lockDuration * 2000);
+            postMessage(new ConsoleMessage($"{threadName}: Will hold lock [{lockName}] for {delay} milliseconds (lease {lockDuration}s, auto-renewed)", this.color));
             await Task.Delay(delay);
         }
     }


### PR DESCRIPTION
Fixes #32.

## Problem
If a worker held the lock and its work ran **longer than the lease TTL**, the lease document expired (Cosmos TTL) **mid-work**, so another worker saw no valid lease and acquired the lock — two workers running at once. The sample even detected this and printed `Lock ... was lost because of TTL ==> ERROR`.

## Fix: automatic lease renewal (heartbeat)
While a worker holds the lock, `LockManager` renews its lease on a background timer (every ~half the lease duration) until the lock is released or disposed. So the lease never expires while the holder is alive and **no other worker can start**. If the holder finishes or crashes it stops renewing, the lease expires via TTL, and the lock is released automatically — a stalled worker can **never deadlock** the lock.

- **LockManager**: background renewal loop started on acquire, stopped on release/`Dispose`; an optional callback surfaces renewal messages to the demo.
- **DistributedLockService**: adds `RenewLeaseAsync` (re-writes the lease, resetting its TTL).
- **DistributedLock document** now stores `ttl = -1` so the lock (and its monotonically increasing fence token) never expires — only the *lease* carries a TTL. (Previously the lock inherited the container's 60s default TTL and could vanish, resetting the fence token.)
- **LockTest**: work now intentionally runs longer than the lease to exercise renewal; reports `Completed work while still holding lock ==> OK`.
- **README**: documents the renewal behavior.

## Validation (real, against the vNext emulator)
With a **2 s lease** and work running **2–4 s**:
- The holder emitted `Renewed lease ... while work continues` and finished with `Completed work while still holding lock ==> OK` — the `lost because of TTL ==> ERROR` no longer appears.
- The other two threads repeatedly reported `FAILED` to acquire while the holder worked (**mutual exclusion preserved even though work > lease**).
- Fence tokens incremented monotonically (1 → 2 → …).

This also aligns the sample's behavior with the CloudDistributedLock approach referenced in #66, which is a natural follow-up.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>