### PR TITLE
Add an interactive web front end for the distributed-lock sample

### DIFF
--- a/distributed-lock/README.md
+++ b/distributed-lock/README.md
@@ -65,7 +65,10 @@ using (var @lock = await lockProvider.TryAcquireLockAsync("my-resource"))
 using var waited = await lockProvider.AcquireLockAsync("my-resource", TimeSpan.FromSeconds(2));
 ```
 
-The included console app (`source/ConsoleApp`) starts three workers that all compete for the same lock to show that only one holds it at a time, that the holder keeps the lock while its work runs longer than the TTL, and that each acquisition prints a higher fencing token.
+This sample ships two ways to explore the pattern:
+
+- An **interactive web front end** (`source/Website`) — a visual playground where several on-screen "workers" compete for **real** Cosmos DB locks. Adjust how long work takes, toggle the keep-alive renewal, crash a holder, and watch a **fencing token** reject a stale writer. This is the best way to *see* how the lock behaves and why it's useful.
+- A **console app** (`source/ConsoleApp`) that starts three workers competing for the same lock — a quick, scriptable run showing only one holder at a time, the keep-alive holding the lock past the TTL, and a monotonically increasing fencing token.
 
 ## Getting the code
 
@@ -143,48 +146,45 @@ If you are using the Azure Cosmos DB Emulator or cannot use RBAC, set `CosmosKey
 
 ## Run the demo locally
 
-1. Start the local emulator (see the [root README](../README.md#run-locally-with-the-emulator-default)) or point at your own account, then run the console app:
+Start the local emulator first (see the [root README](../README.md#run-locally-with-the-emulator-default)), or point at your own account.
 
-    ```bash
-    cd source/ConsoleApp
-    dotnet run
-    ```
+### Interactive web front end (recommended)
 
-1. The app starts three workers competing for the same lock. Notice that only one holds it at a time (the others log `could not acquire (held by another worker)`), that the holder keeps the lock even when its work runs longer than the TTL (`holding for ... ms (TTL 5s, auto-renewed)`), and that each acquisition prints a higher `fencing token`. It finishes by demonstrating an `AcquireLockAsync` call that gives up after a 2-second wait while the lock is held.
+```bash
+cd source/Website
+dotnet run
+```
+
+Open the URL it prints. Several workers immediately start competing for a lock. Try dragging a worker's **Work** slider past the **Lock TTL**, toggling **Auto-renew** off, clicking **💥 Crash** on the current holder, and switching a worker to **Wait** mode — the on-screen "Things to try" list walks through the key experiments (mutual exclusion, renewal, fencing tokens, and crash/TTL recovery).
+
+### Console app
+
+```bash
+cd source/ConsoleApp
+dotnet run
+```
+
+The console app starts three workers competing for the same lock. Only one holds it at a time (the others log `could not acquire`), the holder keeps the lock even when its work runs longer than the TTL, and each acquisition prints a higher `fencing token`.
 
 ## (Optional) Deploy and run in Azure with `azd`
 
-The steps above run the sample **all-local** (against the Azure Cosmos DB emulator or your own account). If you'd rather run it against a dedicated, **keyless** Azure Cosmos DB account in Azure, this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd provision`.
+The steps above run the sample **all-local**. If you'd rather run the **all-Azure** way — the interactive web front end hosted in Azure over a keyless Cosmos DB account — this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd up`.
 
-Because this sample is a **console app**, there is no service hosted in Azure — `azd` only provisions the data store, intentionally minimal and cheap:
+It provisions and deploys, intentionally minimal and cheap:
 
-- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**.
-- The sample's `LockDB` database and `Locks` container (TTL-enabled, so an abandoned lock is released automatically), pre-created.
-- A data-plane role assignment granting **you** (the deploying user) keyless access, so you can run the console app locally against it.
+- An **App Service** web app (Basic **B1**) hosting the interactive front end.
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**, with the `LockDB` database and TTL-enabled `Locks` container pre-created.
+- The web app reaches Cosmos DB **keyless**, via a **user-assigned managed identity** — no keys or connection strings are stored anywhere. The deploying user is also granted data access so you can run the console app locally against the same account.
 
-### Provision
+### Deploy
 
 From the `distributed-lock` folder:
 
 ```bash
-azd provision
+azd up
 ```
 
-When it finishes, point the app at the new account and run it locally — keyless, using your `az login` credentials:
-
-```bash
-# bash / zsh
-export CosmosUri="$(azd env get-value AZURE_COSMOS_ENDPOINT)"
-cd source/ConsoleApp && dotnet run
-```
-
-```powershell
-# PowerShell
-$env:CosmosUri = azd env get-value AZURE_COSMOS_ENDPOINT
-cd source/ConsoleApp; dotnet run
-```
-
-Leave `CosmosKey` empty — with only `CosmosUri` set, the app authenticates keyless via `DefaultAzureCredential`.
+`azd` prompts for an environment name, subscription, and location, then provisions the resources and deploys the front end. When it finishes it prints the site URL — open it and start experimenting.
 
 > **Consistency note:** This template provisions a single-region **serverless** account, which uses **Session** consistency. The lock's mutual exclusion comes from the atomic unique-id insert (a 409 Conflict when the lock is held) and ETag-checked renewal, so it holds under any consistency level; the fencing token is the session token's global LSN, which is monotonically increasing. For a multi-region *production* lock you would instead use provisioned throughput with **Strong** consistency; serverless accounts are single-region only.
 

--- a/distributed-lock/azure.yaml
+++ b/distributed-lock/azure.yaml
@@ -3,6 +3,11 @@
 name: cosmos-db-design-patterns-distributed-lock
 metadata:
   template: cosmos-db-design-patterns-distributed-lock
-# This is a console sample: azd only provisions the (keyless, serverless) Cosmos DB
-# account and grants the deploying user data-plane access. There is no service to
-# deploy; run the console app locally with `dotnet run` after `azd provision`.
+# azd deploys the interactive web front end to App Service. The console app under
+# source/ConsoleApp is an optional local driver you can run with `dotnet run` against the
+# same provisioned (keyless) Cosmos account.
+services:
+  web:
+    project: ./source/Website
+    language: dotnet
+    host: appservice

--- a/distributed-lock/infra/main.bicep
+++ b/distributed-lock/infra/main.bicep
@@ -36,3 +36,4 @@ module resources 'resources.bicep' = {
 }
 
 output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_WEB_URL string = resources.outputs.webUrl

--- a/distributed-lock/infra/resources.bicep
+++ b/distributed-lock/infra/resources.bicep
@@ -1,4 +1,4 @@
-metadata description = 'Resources for the distributed-lock console sample: a serverless, keyless Azure Cosmos DB account with the sample database/container pre-created and data-plane access granted to the deploying user. The Locks container is created with a 60-second TTL so leases auto-expire, matching the app. The account uses the shared module default (Session consistency); lock safety comes from optimistic concurrency (ETag + unique-id conditional writes), not the consistency level.'
+metadata description = 'Resources for the distributed-lock sample: the interactive web front end on App Service (keyless, via managed identity) over a serverless, keyless Azure Cosmos DB account. Reuses the shared web-app and secure-cosmos modules. The Locks container is TTL-enabled so an abandoned lock is released automatically; the app sets each lock record\'s own TTL. The account uses the shared module default (Session consistency); lock safety comes from optimistic concurrency (a unique-id insert plus ETag-checked renewal), not the consistency level.'
 
 @description('Location for all resources.')
 param location string
@@ -9,9 +9,31 @@ param tags object = {}
 @description('Short unique token used to name resources.')
 param resourceToken string
 
-@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs.')
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs (e.g. the console app).')
 param principalId string = ''
 
+// Interactive web front end + user-assigned identity (shared module). It only touches Cosmos
+// while a browser is connected, so it does not need "Always On". The Cosmos endpoint is derived
+// from the account name to avoid a dependency cycle (the Cosmos account is granted access to
+// this app's identity).
+module web '../../infra/core/web-app.bicep' = {
+  name: 'web-app'
+  params: {
+    name: 'web-${resourceToken}'
+    location: location
+    tags: union(tags, { 'azd-service-name': 'web' })
+    alwaysOn: false
+    appSettings: [
+      {
+        name: 'CosmosUri'
+        value: 'https://cosmos-${resourceToken}.documents.azure.com:443/'
+      }
+    ]
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database/container pre-created and data-plane
+// access granted to the web app's identity (and the deploying user, who can run the console app).
 module cosmos '../../infra/core/secure-cosmos.bicep' = {
   name: 'secure-cosmos'
   params: {
@@ -28,12 +50,17 @@ module cosmos '../../infra/core/secure-cosmos.bicep' = {
         databaseName: 'LockDB'
         name: 'Locks'
         partitionKey: '/id'
-        defaultTtl: 60
+        defaultTtl: -1
       }
     ]
-    dataContributorPrincipalIds: empty(principalId) ? [] : [ principalId ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ web.outputs.identityPrincipalId ]
+      : [ web.outputs.identityPrincipalId, principalId ]
   }
 }
 
 @description('The Cosmos DB document endpoint.')
 output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed web front end URL.')
+output webUrl string = web.outputs.url

--- a/distributed-lock/source/CosmosDistributedLock/CosmosDistributedLock.cs
+++ b/distributed-lock/source/CosmosDistributedLock/CosmosDistributedLock.cs
@@ -18,28 +18,38 @@ namespace Cosmos.DistributedLock
         private readonly Task? keepAliveTask;
         private int disposed;
 
+        /// <summary>Raised each time the lock's lease is successfully renewed.</summary>
+        public event Action? Renewed;
+
         internal static CosmosDistributedLock CreateUnacquiredLock()
         {
             return new CosmosDistributedLock();
         }
 
-        internal static CosmosDistributedLock CreateAcquiredLock(ICosmosLockClient cosmosLockClient, ItemResponse<LockRecord> item)
+        internal static CosmosDistributedLock CreateAcquiredLock(ICosmosLockClient cosmosLockClient, ItemResponse<LockRecord> item, bool autoRenew = true)
         {
-            return new CosmosDistributedLock(cosmosLockClient, item);
+            return new CosmosDistributedLock(cosmosLockClient, item, autoRenew);
         }
 
         private CosmosDistributedLock()
         {
         }
 
-        private CosmosDistributedLock(ICosmosLockClient cosmosLockClient, ItemResponse<LockRecord> item)
+        private CosmosDistributedLock(ICosmosLockClient cosmosLockClient, ItemResponse<LockRecord> item, bool autoRenew)
         {
             this.cosmosLockClient = cosmosLockClient;
             latestItem = item;
             fencingToken = SessionTokenParser.Parse(item.Headers.Session);
             lockId = $"{item.Resource.providerName}:{item.Resource.id}:{fencingToken}:{item.Resource.lockObtainedAt.Ticks}";
             cts = new CancellationTokenSource();
-            keepAliveTask = KeepAliveLoop(item, cts.Token);
+
+            // Production callers use automatic keep-alive. The distributed-lock web front end
+            // disables it so it can drive/observe renewal itself (and demonstrate the failure
+            // mode when a lock is NOT renewed).
+            if (autoRenew)
+            {
+                keepAliveTask = KeepAliveLoop(item, cts.Token);
+            }
         }
 
         /// <summary>True when this attempt acquired the lock.</summary>
@@ -52,6 +62,34 @@ namespace Cosmos.DistributedLock
         public long FencingToken => fencingToken;
 
         public string? ETag => latestItem?.ETag;
+
+        /// <summary>When the lock's lease was last renewed (useful for a TTL countdown).</summary>
+        public DateTimeOffset? LockLastRenewedAt => latestItem?.Resource.lockLastRenewedAt;
+
+        /// <summary>The lock's time-to-live, in seconds.</summary>
+        public int Ttl => latestItem?.Resource._ttl ?? 0;
+
+        /// <summary>
+        /// Manually renews the lock's lease (resetting its TTL). Returns <c>false</c> if the lock
+        /// was lost — for example it already expired via TTL or was taken over by someone else.
+        /// Useful when the lock was acquired with automatic keep-alive disabled.
+        /// </summary>
+        public async Task<bool> TryRenewAsync()
+        {
+            var current = latestItem;
+            if (cosmosLockClient == null || current == null) return false;
+
+            var updated = await cosmosLockClient.RenewLockAsync(current).ConfigureAwait(false);
+            if (updated == null)
+            {
+                latestItem = null; // lock lost
+                return false;
+            }
+
+            latestItem = updated;
+            Renewed?.Invoke();
+            return true;
+        }
 
         private async Task KeepAliveLoop(ItemResponse<LockRecord> item, CancellationToken cancellationToken)
         {
@@ -74,6 +112,7 @@ namespace Cosmos.DistributedLock
 
                     current = updatedItem;
                     latestItem = updatedItem;
+                    Renewed?.Invoke();
                 }
                 catch (OperationCanceledException)
                 {

--- a/distributed-lock/source/CosmosDistributedLock/CosmosDistributedLockProvider.cs
+++ b/distributed-lock/source/CosmosDistributedLock/CosmosDistributedLockProvider.cs
@@ -3,10 +3,10 @@ namespace Cosmos.DistributedLock
     public interface ICosmosDistributedLockProvider
     {
         /// <summary>Tries to acquire the lock once and returns immediately.</summary>
-        Task<CosmosDistributedLock> TryAcquireLockAsync(string name);
+        Task<CosmosDistributedLock> TryAcquireLockAsync(string name, bool autoRenew = true, int? ttlSeconds = null);
 
         /// <summary>Waits (indefinitely, or up to <paramref name="timeout"/>) for the lock.</summary>
-        Task<CosmosDistributedLock> AcquireLockAsync(string name, TimeSpan? timeout = default);
+        Task<CosmosDistributedLock> AcquireLockAsync(string name, TimeSpan? timeout = default, bool autoRenew = true, int? ttlSeconds = null);
     }
 
     internal class CosmosDistributedLockProvider : ICosmosDistributedLockProvider
@@ -26,18 +26,18 @@ namespace Cosmos.DistributedLock
             this.cosmosLockClient = cosmosLockClient;
         }
 
-        public async Task<CosmosDistributedLock> AcquireLockAsync(string name, TimeSpan? timeout = null)
+        public async Task<CosmosDistributedLock> AcquireLockAsync(string name, TimeSpan? timeout = null, bool autoRenew = true, int? ttlSeconds = null)
         {
             using var cancellationTokenSource = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : new CancellationTokenSource();
-            return await ContinuallyTryAcquireLockAsync(name, cancellationTokenSource.Token).ConfigureAwait(false);
+            return await ContinuallyTryAcquireLockAsync(name, autoRenew, ttlSeconds, cancellationTokenSource.Token).ConfigureAwait(false);
         }
 
-        public async Task<CosmosDistributedLock> TryAcquireLockAsync(string name)
+        public async Task<CosmosDistributedLock> TryAcquireLockAsync(string name, bool autoRenew = true, int? ttlSeconds = null)
         {
-            var item = await cosmosLockClient.TryAcquireLockAsync(name).ConfigureAwait(false);
+            var item = await cosmosLockClient.TryAcquireLockAsync(name, ttlSeconds).ConfigureAwait(false);
             if (item != null)
             {
-                return CosmosDistributedLock.CreateAcquiredLock(cosmosLockClient, item);
+                return CosmosDistributedLock.CreateAcquiredLock(cosmosLockClient, item, autoRenew);
             }
             else
             {
@@ -45,11 +45,11 @@ namespace Cosmos.DistributedLock
             }
         }
 
-        private async Task<CosmosDistributedLock> ContinuallyTryAcquireLockAsync(string name, CancellationToken cancellationToken)
+        private async Task<CosmosDistributedLock> ContinuallyTryAcquireLockAsync(string name, bool autoRenew, int? ttlSeconds, CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var @lock = await TryAcquireLockAsync(name).ConfigureAwait(false);
+                var @lock = await TryAcquireLockAsync(name, autoRenew, ttlSeconds).ConfigureAwait(false);
                 if (@lock.IsAcquired)
                 {
                     return @lock;

--- a/distributed-lock/source/CosmosDistributedLock/CosmosLockClient.cs
+++ b/distributed-lock/source/CosmosDistributedLock/CosmosLockClient.cs
@@ -5,7 +5,7 @@ namespace Cosmos.DistributedLock
 {
     internal interface ICosmosLockClient
     {
-        Task<ItemResponse<LockRecord>?> TryAcquireLockAsync(string name);
+        Task<ItemResponse<LockRecord>?> TryAcquireLockAsync(string name, int? ttlSeconds = null);
         Task<ItemResponse<LockRecord>?> RenewLockAsync(ItemResponse<LockRecord> item);
         Task ReleaseLockAsync(ItemResponse<LockRecord> item);
     }
@@ -21,7 +21,7 @@ namespace Cosmos.DistributedLock
             container = options.CosmosClient!.GetContainer(options.DatabaseName, options.ContainerName);
         }
 
-        public async Task<ItemResponse<LockRecord>?> TryAcquireLockAsync(string name)
+        public async Task<ItemResponse<LockRecord>?> TryAcquireLockAsync(string name, int? ttlSeconds = null)
         {
             try
             {
@@ -37,7 +37,7 @@ namespace Cosmos.DistributedLock
                     providerName = options.ProviderName,
                     lockObtainedAt = now,
                     lockLastRenewedAt = now,
-                    _ttl = options.TTL
+                    _ttl = ttlSeconds ?? options.TTL
                 };
                 return await container.CreateItemAsync(lockRecord, new PartitionKey(lockRecord.id)).ConfigureAwait(false);
             }

--- a/distributed-lock/source/Website/App.razor
+++ b/distributed-lock/source/Website/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(DistributedLockWeb.Shared.MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(DistributedLockWeb.Shared.MainLayout)">
+            <p role="alert">Page not found.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/distributed-lock/source/Website/Pages/Index.razor
+++ b/distributed-lock/source/Website/Pages/Index.razor
@@ -27,11 +27,14 @@
         </div>
     </header>
 
-    @if (_initError != null)
+    @if (_connecting)
+    {
+        <div class="info-banner">Connecting to Azure Cosmos DB…</div>
+    }
+    else if (_initError != null)
     {
         <div class="error-banner">
-            Could not reach Azure Cosmos DB: <code>@_initError</code>. If running locally, start the emulator with
-            <code>docker compose up -d</code> from the repo root, then click <strong>Start all</strong>.
+            @_initError
         </div>
     }
 
@@ -182,16 +185,15 @@
 
 @code {
     private string? _initError;
+    private bool _connecting;
     private PeriodicTimer? _timer;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
         Sim.Changed += OnChanged;
-        try { await Sim.StartAllAsync(); _initError = null; }
-        catch (Exception ex) { _initError = ex.Message; }
+        await StartAll();
         _ = RefreshLoop();
-        await InvokeAsync(StateHasChanged);
     }
 
     private async Task RefreshLoop()
@@ -211,8 +213,22 @@
 
     private async Task StartAll()
     {
-        try { await Sim.StartAllAsync(); _initError = null; }
-        catch (Exception ex) { _initError = ex.Message; }
+        _connecting = true;
+        _initError = null;
+        await InvokeAsync(StateHasChanged);
+        try
+        {
+            await Sim.StartAllAsync();
+        }
+        catch (Exception ex)
+        {
+            _initError = ex.Message;
+        }
+        finally
+        {
+            _connecting = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     private async Task Reset() => await Sim.ResetAsync();

--- a/distributed-lock/source/Website/Pages/Index.razor
+++ b/distributed-lock/source/Website/Pages/Index.razor
@@ -1,0 +1,260 @@
+@page "/"
+@implements IDisposable
+@inject SimulationService Sim
+
+<div class="app">
+    <header class="hero">
+        <div class="hero-title">
+            <span class="lock-emoji">🔒</span>
+            <div>
+                <h1>Azure Cosmos DB · Distributed Lock</h1>
+                <p>A live, interactive playground. Every <em>acquire</em>, <em>renewal</em>, and <em>release</em> below is a <strong>real</strong> operation against Azure Cosmos DB.</p>
+            </div>
+        </div>
+        <div class="toolbar">
+            <button class="btn primary" @onclick="StartAll">▶ Start all</button>
+            <button class="btn" @onclick="() => Sim.StopAll()">⏸ Stop all</button>
+            <button class="btn" @onclick="Reset">↺ Reset</button>
+            <button class="btn" @onclick="() => Sim.AddWorker()">＋ Worker</button>
+            <div class="slider-inline">
+                <label>Lock TTL <strong>@Sim.TtlSeconds s</strong></label>
+                <input type="range" min="2" max="20" value="@Sim.TtlSeconds" @onchange="OnTtl" />
+            </div>
+            <div class="slider-inline">
+                <label>Retry pace <strong>@Sim.Pace.ToString("0.0")×</strong></label>
+                <input type="range" min="0.5" max="3" step="0.25" value="@Sim.Pace" @onchange="OnPace" />
+            </div>
+        </div>
+    </header>
+
+    @if (_initError != null)
+    {
+        <div class="error-banner">
+            Could not reach Azure Cosmos DB: <code>@_initError</code>. If running locally, start the emulator with
+            <code>docker compose up -d</code> from the repo root, then click <strong>Start all</strong>.
+        </div>
+    }
+
+    <section class="workers">
+        @foreach (var w in Sim.Workers)
+        {
+            <div class="worker-card @StateClass(w)" style="--accent:@w.Color">
+                <div class="worker-head">
+                    <span class="dot" style="background:@w.Color"></span>
+                    <span class="worker-name">@w.Name</span>
+                    <span class="state-badge @StateClass(w)">@StateLabel(w)</span>
+                </div>
+
+                @if (w.State == WorkerState.Holding)
+                {
+                    <div class="hold-info">
+                        <div class="fence">
+                            fencing token <strong>@w.FencingToken</strong>
+                            @if (w.RenewalEnabled)
+                            {
+                                <span class="heartbeat" title="auto-renewing lease">💓</span>
+                            }
+                        </div>
+                        <div class="lease-bar @(w.LockExpiredWhileWorking ? "expired" : "")">
+                            <div class="lease-fill" style="width:@(((w.LockExpiredWhileWorking ? 0 : w.LeaseFraction) * 100).ToString("0"))%"></div>
+                            <span class="lease-text">
+                                @(w.LockExpiredWhileWorking ? "LEASE EXPIRED — still working!" : $"lease {w.LeaseSecondsRemaining:0.0}s · renewals {w.RenewCount}")
+                            </span>
+                        </div>
+                    </div>
+                }
+                else if (!string.IsNullOrEmpty(w.Status))
+                {
+                    <div class="worker-status">@w.Status</div>
+                }
+
+                <div class="controls">
+                    <label class="ctl">
+                        <span>Work <strong>@w.WorkDurationSeconds s</strong> @(w.WorkDurationSeconds > Sim.TtlSeconds ? "· longer than TTL" : "")</span>
+                        <input type="range" min="1" max="20" value="@w.WorkDurationSeconds" @onchange="e => Sim.SetWorkDuration(w.Id, ParseInt(e))" />
+                    </label>
+
+                    <label class="switch">
+                        <input type="checkbox" checked="@w.RenewalEnabled" @onchange="e => Sim.SetRenewal(w.Id, (bool)e.Value!)" />
+                        <span>Auto-renew (keep-alive)</span>
+                    </label>
+
+                    <div class="ctl-row">
+                        <label class="mini">
+                            Mode
+                            <select value="@ModeVal(w)" @onchange="e => Sim.SetWaitMode(w.Id, IsWait(e))">
+                                <option value="try">Try (fail fast)</option>
+                                <option value="wait">Wait (timeout)</option>
+                            </select>
+                        </label>
+                        <label class="mini">
+                            Lock
+                            <select value="@w.LockName" @onchange="e => Sim.SetLockName(w.Id, StringVal(e))">
+                                @foreach (var n in Sim.LockNames)
+                                {
+                                    <option value="@n">@n</option>
+                                }
+                            </select>
+                        </label>
+                    </div>
+
+                    @if (w.WaitMode)
+                    {
+                        <label class="ctl">
+                            <span>Wait timeout <strong>@w.WaitTimeoutSeconds s</strong></span>
+                            <input type="range" min="1" max="20" value="@w.WaitTimeoutSeconds" @onchange="e => Sim.SetWaitTimeout(w.Id, ParseInt(e))" />
+                        </label>
+                    }
+
+                    <div class="btn-row">
+                        @if (w.Running)
+                        {
+                            <button class="btn tiny" @onclick="() => Sim.StopWorker(w.Id)">Stop</button>
+                        }
+                        else
+                        {
+                            <button class="btn tiny primary" @onclick="() => Sim.StartWorker(w.Id)">Start</button>
+                        }
+                        <button class="btn tiny danger" @onclick="() => Sim.CrashWorker(w.Id)" disabled="@(w.State != WorkerState.Holding)">💥 Crash</button>
+                        <button class="btn tiny ghost" @onclick="() => Sim.RemoveWorker(w.Id)" title="remove worker">✕</button>
+                    </div>
+                </div>
+            </div>
+        }
+    </section>
+
+    <section class="lower">
+        <div class="resources">
+            <h2>Protected resources <span class="hint">only the current holder's fencing token is accepted</span></h2>
+            @foreach (var r in Sim.ActiveResources)
+            {
+                <div class="resource-card">
+                    <div class="resource-head">
+                        <span class="res-name">@r.Name</span>
+                        <span class="res-holder" style="color:@(r.LastWriterColor ?? "#94a3b8")">
+                            last write: @(r.LastWriter ?? "—") · token @r.LastToken
+                        </span>
+                    </div>
+                    <div class="res-stats">
+                        <div class="stat ok"><strong>@r.WriteCount</strong><span>accepted</span></div>
+                        <div class="stat bad @(r.RejectedCount > 0 ? "flash" : "")"><strong>@r.RejectedCount</strong><span>rejected (stale)</span></div>
+                        <div class="stat"><strong>@r.HighestTokenSeen</strong><span>highest token</span></div>
+                    </div>
+                    @if (r.RejectedCount > 0 && r.LastRejectedWriter != null)
+                    {
+                        <div class="reject-note" style="border-color:@r.LastRejectedColor">
+                            <strong style="color:@r.LastRejectedColor">@r.LastRejectedWriter</strong>'s write with stale token
+                            <strong>@r.LastRejectedToken</strong> was rejected — its lock had expired and a newer holder took over.
+                        </div>
+                    }
+                    <pre class="lock-doc">@Sim.CurrentLockDocumentJson(r.Name)</pre>
+                </div>
+            }
+        </div>
+
+        <div class="timeline">
+            <h2>Event timeline</h2>
+            <div class="log">
+                @foreach (var e in Sim.RecentLog)
+                {
+                    <div class="log-row @LevelClass(e.Level)">
+                        <span class="log-time">@e.TimeUtc.ToLocalTime().ToString("HH:mm:ss")</span>
+                        <span class="log-worker" style="color:@e.Color">@e.Worker</span>
+                        <span class="log-msg">@e.Message</span>
+                    </div>
+                }
+            </div>
+        </div>
+    </section>
+
+    <section class="explain">
+        <h2>Things to try</h2>
+        <ul>
+            <li><strong>Mutual exclusion:</strong> only one worker holds a lock at a time — the others show “could not acquire”.</li>
+            <li><strong>Renewal:</strong> drag <em>Work</em> longer than the TTL. With <em>Auto-renew</em> on, the holder keeps the lock (the lease bar keeps refilling).</li>
+            <li><strong>Break it (why fencing tokens matter):</strong> turn <em>Auto-renew</em> OFF and set <em>Work</em> &gt; TTL. The lease expires mid-work, another worker acquires, and the stale holder's writes are <em>rejected</em> by the fencing token.</li>
+            <li><strong>Crash a holder:</strong> click 💥 while it holds the lock — it stops without releasing, and the lock auto-releases via TTL (no deadlock).</li>
+            <li><strong>Wait vs Try:</strong> switch a worker to “Wait (timeout)” to watch it queue and then give up.</li>
+            <li><strong>Granularity:</strong> point some workers at <code>resource-B</code> — different lock names never block each other.</li>
+        </ul>
+    </section>
+</div>
+
+@code {
+    private string? _initError;
+    private PeriodicTimer? _timer;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        Sim.Changed += OnChanged;
+        try { await Sim.StartAllAsync(); _initError = null; }
+        catch (Exception ex) { _initError = ex.Message; }
+        _ = RefreshLoop();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RefreshLoop()
+    {
+        _timer = new PeriodicTimer(TimeSpan.FromMilliseconds(200));
+        try
+        {
+            while (await _timer.WaitForNextTickAsync())
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch { }
+    }
+
+    private void OnChanged() => _ = InvokeAsync(StateHasChanged);
+
+    private async Task StartAll()
+    {
+        try { await Sim.StartAllAsync(); _initError = null; }
+        catch (Exception ex) { _initError = ex.Message; }
+    }
+
+    private async Task Reset() => await Sim.ResetAsync();
+
+    private void OnTtl(ChangeEventArgs e) => Sim.SetTtl(ParseInt(e));
+    private void OnPace(ChangeEventArgs e) => Sim.SetPace(ParseDouble(e));
+
+    private static int ParseInt(ChangeEventArgs e) => int.TryParse(e.Value?.ToString(), out var v) ? v : 0;
+    private static double ParseDouble(ChangeEventArgs e) => double.TryParse(e.Value?.ToString(), out var v) ? v : 1.0;
+    private static string StringVal(ChangeEventArgs e) => e.Value?.ToString() ?? "";
+    private static bool IsWait(ChangeEventArgs e) => e.Value?.ToString() == "wait";
+    private static string ModeVal(Worker w) => w.WaitMode ? "wait" : "try";
+
+    private static string StateClass(Worker w) => w.State switch
+    {
+        WorkerState.Holding => w.LockExpiredWhileWorking ? "state-danger" : "state-holding",
+        WorkerState.Trying => "state-trying",
+        WorkerState.Waiting => "state-waiting",
+        WorkerState.Crashed => "state-crashed",
+        _ => "state-idle"
+    };
+
+    private static string StateLabel(Worker w) => w.State switch
+    {
+        WorkerState.Holding => w.LockExpiredWhileWorking ? "HOLDING · lease lost!" : "HOLDING",
+        WorkerState.Trying => "trying…",
+        WorkerState.Waiting => "waiting…",
+        WorkerState.Crashed => "CRASHED",
+        _ => w.Running ? "idle" : "stopped"
+    };
+
+    private static string LevelClass(LogLevel l) => l switch
+    {
+        LogLevel.Success => "lvl-ok",
+        LogLevel.Warn => "lvl-warn",
+        LogLevel.Error => "lvl-err",
+        _ => "lvl-info"
+    };
+
+    public void Dispose()
+    {
+        Sim.Changed -= OnChanged;
+        _timer?.Dispose();
+    }
+}

--- a/distributed-lock/source/Website/Pages/_Host.cshtml
+++ b/distributed-lock/source/Website/Pages/_Host.cshtml
@@ -1,0 +1,28 @@
+@page "/"
+@namespace DistributedLockWeb.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Azure Cosmos DB · Distributed Lock — Interactive</title>
+    <base href="~/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="stylesheet" href="css/site.css" />
+</head>
+<body>
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/distributed-lock/source/Website/Program.cs
+++ b/distributed-lock/source/Website/Program.cs
@@ -1,0 +1,43 @@
+using Cosmos.DistributedLock;
+using DistributedLockWeb.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddEnvironmentVariables();
+
+string endpoint = builder.Configuration["CosmosUri"] ?? string.Empty;
+string? key = builder.Configuration["CosmosKey"];
+
+const string databaseName = "LockDB";
+const string containerName = "Locks";
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+// Register the REAL distributed-lock provider. Keyless (DefaultAzureCredential) when no key is
+// set, key-based otherwise; the localhost emulator's self-signed certificate is accepted
+// automatically. TTL is a starting value; the UI can change it per acquisition.
+builder.Services.AddCosmosDistributedLock(endpoint, key, databaseName, ttl: 8, o => o.ContainerName = containerName);
+
+// The simulation engine drives on-screen "workers" that use the real lock provider.
+builder.Services.AddSingleton(sp => new SimulationService(
+    sp.GetRequiredService<ICosmosDistributedLockProviderFactory>(),
+    endpoint,
+    key,
+    databaseName,
+    containerName));
+
+var app = builder.Build();
+
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+}
+
+app.UseStaticFiles();
+app.UseRouting();
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/distributed-lock/source/Website/Program.cs
+++ b/distributed-lock/source/Website/Program.cs
@@ -3,10 +3,27 @@ using DistributedLockWeb.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Serve static web assets (including the framework's blazor.server.js) from the manifest in
+// every environment. Without this, `dotnet run` outside Development serves a non-interactive
+// page because the Blazor circuit script 404s.
+builder.WebHost.UseStaticWebAssets();
+
 builder.Configuration.AddEnvironmentVariables();
 
 string endpoint = builder.Configuration["CosmosUri"] ?? string.Empty;
 string? key = builder.Configuration["CosmosKey"];
+
+// Default to the local Azure Cosmos DB emulator when nothing is configured, so the site runs
+// with zero setup once the emulator is started (`docker compose up` from the repo root). In
+// Azure, azd sets CosmosUri to the provisioned account and the app connects keyless.
+if (string.IsNullOrWhiteSpace(endpoint))
+{
+    endpoint = "https://localhost:8081";
+    if (string.IsNullOrEmpty(key))
+    {
+        key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+    }
+}
 
 const string databaseName = "LockDB";
 const string containerName = "Locks";
@@ -28,7 +45,6 @@ builder.Services.AddSingleton(sp => new SimulationService(
     containerName));
 
 var app = builder.Build();
-
 
 if (!app.Environment.IsDevelopment())
 {

--- a/distributed-lock/source/Website/Properties/launchSettings.json
+++ b/distributed-lock/source/Website/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "Website": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5230",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/distributed-lock/source/Website/Services/Models.cs
+++ b/distributed-lock/source/Website/Services/Models.cs
@@ -1,0 +1,104 @@
+namespace DistributedLockWeb.Services;
+
+public enum WorkerState
+{
+    Idle,
+    Trying,
+    Waiting,
+    Holding,
+    Crashed
+}
+
+/// <summary>
+/// One on-screen "worker" (an independent process competing for a lock). Holds both its
+/// user-controlled settings and its live runtime state. All fields are read by the UI and
+/// written by the worker's background loop; the <see cref="SimulationService"/> guards mutations.
+/// </summary>
+public class Worker
+{
+    public Guid Id { get; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public string Color { get; set; } = "#38bdf8";
+
+    // ---- Settings (user controlled) ----
+    public string LockName { get; set; } = "resource-A";
+    public int WorkDurationSeconds { get; set; } = 6;
+    public bool RenewalEnabled { get; set; } = true;
+    public bool WaitMode { get; set; }                 // false = TryAcquire (fail fast), true = AcquireLock(timeout)
+    public int WaitTimeoutSeconds { get; set; } = 5;
+
+    // ---- Live runtime state ----
+    public WorkerState State { get; set; } = WorkerState.Idle;
+    public long FencingToken { get; set; }
+    public int TtlSeconds { get; set; }
+    public DateTimeOffset? HoldStartedUtc { get; set; }
+    public DateTimeOffset? WorkEndsUtc { get; set; }
+    public DateTimeOffset? LeaseExpiresUtc { get; set; }
+    public int RenewCount { get; set; }
+    public bool Running { get; set; }
+    public bool LockExpiredWhileWorking { get; set; }
+    public string? Status { get; set; }
+
+    internal CancellationTokenSource? Cts { get; set; }
+    internal Task? LoopTask { get; set; }
+    internal Cosmos.DistributedLock.CosmosDistributedLock? CurrentLock { get; set; }
+
+    /// <summary>Seconds remaining until the lease would expire (for the countdown bar).</summary>
+    public double LeaseSecondsRemaining =>
+        LeaseExpiresUtc is { } exp ? Math.Max(0, (exp - DateTimeOffset.UtcNow).TotalSeconds) : 0;
+
+    public double LeaseFraction =>
+        TtlSeconds > 0 ? Math.Clamp(LeaseSecondsRemaining / TtlSeconds, 0, 1) : 0;
+}
+
+/// <summary>
+/// Shared state that only the true lock holder should modify. It accepts a write only when the
+/// caller's fencing token is at least the highest token it has ever seen — so a stale holder
+/// (one whose lock expired) is rejected. This demonstrates why fencing tokens matter.
+/// </summary>
+public class ProtectedResource
+{
+    private readonly object _sync = new();
+
+    public string Name { get; }
+    public long WriteCount { get; private set; }
+    public long RejectedCount { get; private set; }
+    public long HighestTokenSeen { get; private set; }
+    public string? LastWriter { get; private set; }
+    public long LastToken { get; private set; }
+    public DateTimeOffset LastWriteUtc { get; private set; }
+
+    public ProtectedResource(string name) => Name = name;
+
+    public bool TryWrite(string writer, string color, long fencingToken)
+    {
+        lock (_sync)
+        {
+            if (fencingToken < HighestTokenSeen)
+            {
+                RejectedCount++;
+                LastRejectedWriter = writer;
+                LastRejectedColor = color;
+                LastRejectedToken = fencingToken;
+                return false;
+            }
+
+            HighestTokenSeen = fencingToken;
+            WriteCount++;
+            LastWriter = writer;
+            LastWriterColor = color;
+            LastToken = fencingToken;
+            LastWriteUtc = DateTimeOffset.UtcNow;
+            return true;
+        }
+    }
+
+    public string? LastWriterColor { get; private set; }
+    public string? LastRejectedWriter { get; private set; }
+    public string? LastRejectedColor { get; private set; }
+    public long LastRejectedToken { get; private set; }
+}
+
+public enum LogLevel { Info, Success, Warn, Error }
+
+public record LogEntry(DateTimeOffset TimeUtc, string Worker, string Color, string Message, LogLevel Level);

--- a/distributed-lock/source/Website/Services/SimulationService.cs
+++ b/distributed-lock/source/Website/Services/SimulationService.cs
@@ -1,0 +1,401 @@
+using System.Collections.Concurrent;
+using Cosmos.DistributedLock;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+
+namespace DistributedLockWeb.Services;
+
+/// <summary>
+/// Drives the on-screen "workers" that compete for real Azure Cosmos DB distributed locks and
+/// exposes their live state to the Blazor UI. Every acquire / renew / release is a real
+/// operation against Cosmos via the <c>CosmosDistributedLock</c> library.
+/// </summary>
+public class SimulationService
+{
+    private static readonly string[] Palette =
+        { "#38bdf8", "#f472b6", "#f59e0b", "#a78bfa", "#34d399", "#fb7185", "#60a5fa", "#facc15" };
+
+    private readonly ICosmosDistributedLockProviderFactory _factory;
+    private readonly string _endpoint;
+    private readonly string? _key;
+    private readonly string _databaseName;
+    private readonly string _containerName;
+
+    private readonly List<Worker> _workers = new();
+    private readonly ConcurrentDictionary<string, ProtectedResource> _resources = new();
+    private readonly LinkedList<LogEntry> _log = new();
+    private readonly object _sync = new();
+
+    private int _ttlSeconds = 8;
+    private double _pace = 1.0; // >1 = idle workers retry faster
+    private int _initialized;
+    private int _nameCounter;
+
+    public IReadOnlyList<string> LockNames { get; } = new[] { "resource-A", "resource-B" };
+
+    public event Action? Changed;
+
+    public SimulationService(ICosmosDistributedLockProviderFactory factory, string endpoint, string? key, string databaseName, string containerName)
+    {
+        _factory = factory;
+        _endpoint = endpoint;
+        _key = key;
+        _databaseName = databaseName;
+        _containerName = containerName;
+
+        foreach (var n in new[] { "Worker-A", "Worker-B", "Worker-C" })
+        {
+            AddWorkerInternal(n);
+        }
+    }
+
+    public int TtlSeconds => _ttlSeconds;
+    public double Pace => _pace;
+
+    public IReadOnlyList<Worker> Workers
+    {
+        get { lock (_sync) { return _workers.ToList(); } }
+    }
+
+    public IReadOnlyList<ProtectedResource> ActiveResources
+    {
+        get
+        {
+            var names = Workers.Select(w => w.LockName).Distinct();
+            return names.Select(GetResource).ToList();
+        }
+    }
+
+    public IReadOnlyList<LogEntry> RecentLog
+    {
+        get { lock (_sync) { return _log.ToList(); } }
+    }
+
+    public ProtectedResource GetResource(string lockName) =>
+        _resources.GetOrAdd(lockName, n => new ProtectedResource(n));
+
+    /// <summary>Synthesizes the Cosmos lock document JSON for a lock name from its current holder.</summary>
+    public string CurrentLockDocumentJson(string lockName)
+    {
+        var holder = Workers.FirstOrDefault(w => w.LockName == lockName && w.State == WorkerState.Holding && !w.LockExpiredWhileWorking);
+        if (holder is null)
+        {
+            return $"// no active lock document for \"{lockName}\"\n// (the id would be inserted on acquire)";
+        }
+
+        var doc = new
+        {
+            id = lockName,
+            name = lockName,
+            owner = holder.Name,
+            fencingToken = holder.FencingToken,
+            lockObtainedAt = holder.HoldStartedUtc,
+            lockLastRenewedAt = holder.LeaseExpiresUtc?.AddSeconds(-holder.TtlSeconds),
+            ttl = holder.TtlSeconds
+        };
+        return JsonConvert.SerializeObject(doc, Formatting.Indented);
+    }
+
+    public async Task EnsureInitializedAsync()
+    {
+        if (Interlocked.Exchange(ref _initialized, 1) == 1) return;
+
+        try
+        {
+            using CosmosClient bootstrap = CosmosClientFactory.Create(_endpoint, _key);
+            Database db = await bootstrap.CreateDatabaseIfNotExistsAsync(_databaseName);
+            await db.CreateContainerIfNotExistsAsync(new ContainerProperties
+            {
+                Id = _containerName,
+                PartitionKeyPath = "/id",
+                DefaultTimeToLive = -1
+            });
+        }
+        catch
+        {
+            // Allow retry on a later call (e.g., transient emulator warmup).
+            Interlocked.Exchange(ref _initialized, 0);
+            throw;
+        }
+    }
+
+    // ---- Worker management ----------------------------------------------------------------
+
+    private Worker AddWorkerInternal(string? name = null)
+    {
+        var w = new Worker
+        {
+            Name = name ?? $"Worker-{(char)('A' + _nameCounter)}",
+            Color = Palette[_nameCounter % Palette.Length],
+            LockName = "resource-A",
+            WorkDurationSeconds = 6,
+            RenewalEnabled = true
+        };
+        _nameCounter++;
+        lock (_sync) { _workers.Add(w); }
+        return w;
+    }
+
+    public void AddWorker()
+    {
+        AddWorkerInternal();
+        Notify();
+    }
+
+    public void RemoveWorker(Guid id)
+    {
+        Worker? w;
+        lock (_sync) { w = _workers.FirstOrDefault(x => x.Id == id); }
+        if (w is null) return;
+        StopWorker(id);
+        lock (_sync) { _workers.Remove(w); }
+        Notify();
+    }
+
+    public async Task StartAllAsync()
+    {
+        await EnsureInitializedAsync();
+        foreach (var w in Workers) StartWorker(w.Id);
+    }
+
+    public void StartWorker(Guid id)
+    {
+        var w = Find(id);
+        if (w is null || w.Running) return;
+
+        w.Running = true;
+        w.State = WorkerState.Idle;
+        w.Status = null;
+        w.Cts = new CancellationTokenSource();
+        w.LoopTask = Task.Run(() => RunWorkerAsync(w, w.Cts.Token));
+        Notify();
+    }
+
+    public void StopWorker(Guid id)
+    {
+        var w = Find(id);
+        if (w is null) return;
+        w.Cts?.Cancel();
+        w.Running = false;
+        w.State = WorkerState.Idle;
+        w.Status = "stopped";
+        w.HoldStartedUtc = null;
+        w.WorkEndsUtc = null;
+        w.LeaseExpiresUtc = null;
+        Notify();
+    }
+
+    public void StopAll()
+    {
+        foreach (var w in Workers) StopWorker(w.Id);
+    }
+
+    /// <summary>Simulate a crash: the worker stops WITHOUT releasing its lock, which then expires via TTL.</summary>
+    public void CrashWorker(Guid id)
+    {
+        var w = Find(id);
+        if (w is null) return;
+
+        if (w.State == WorkerState.Holding)
+        {
+            w.State = WorkerState.Crashed; // the loop abandons the lock and exits
+        }
+        else
+        {
+            StopWorker(id);
+        }
+        Notify();
+    }
+
+    public void SetWorkDuration(Guid id, int seconds) { var w = Find(id); if (w != null) { w.WorkDurationSeconds = Math.Clamp(seconds, 1, 30); Notify(); } }
+    public void SetRenewal(Guid id, bool enabled) { var w = Find(id); if (w != null) { w.RenewalEnabled = enabled; Notify(); } }
+    public void SetWaitMode(Guid id, bool wait) { var w = Find(id); if (w != null) { w.WaitMode = wait; Notify(); } }
+    public void SetWaitTimeout(Guid id, int seconds) { var w = Find(id); if (w != null) { w.WaitTimeoutSeconds = Math.Clamp(seconds, 1, 30); Notify(); } }
+    public void SetLockName(Guid id, string name) { var w = Find(id); if (w != null) { w.LockName = name; Notify(); } }
+    public void SetTtl(int seconds) { _ttlSeconds = Math.Clamp(seconds, 2, 30); Notify(); }
+    public void SetPace(double pace) { _pace = Math.Clamp(pace, 0.25, 3.0); Notify(); }
+
+    public async Task ResetAsync()
+    {
+        StopAll();
+        await Task.Delay(200);
+        lock (_sync)
+        {
+            _log.Clear();
+        }
+        _resources.Clear();
+        Notify();
+    }
+
+    // ---- Worker loop ----------------------------------------------------------------------
+
+    private async Task RunWorkerAsync(Worker w, CancellationToken ct)
+    {
+        var provider = _factory.GetLockProvider();
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                w.State = WorkerState.Trying;
+                w.Status = "acquiring…";
+                w.LockExpiredWhileWorking = false;
+                Notify();
+                Log(w, $"attempting to acquire [{w.LockName}]…", LogLevel.Info);
+
+                CosmosDistributedLock @lock;
+                if (w.WaitMode)
+                {
+                    w.State = WorkerState.Waiting;
+                    Notify();
+                    @lock = await provider.AcquireLockAsync(w.LockName, TimeSpan.FromSeconds(w.WaitTimeoutSeconds), autoRenew: false, ttlSeconds: _ttlSeconds);
+                }
+                else
+                {
+                    @lock = await provider.TryAcquireLockAsync(w.LockName, autoRenew: false, ttlSeconds: _ttlSeconds);
+                }
+
+                if (!@lock.IsAcquired)
+                {
+                    @lock.Dispose();
+                    w.State = WorkerState.Idle;
+                    w.Status = w.WaitMode ? "gave up waiting" : "held by another";
+                    Log(w, w.WaitMode
+                        ? $"gave up after {w.WaitTimeoutSeconds}s — [{w.LockName}] still held"
+                        : $"could not acquire [{w.LockName}] — held by another", LogLevel.Warn);
+                    Notify();
+                    await DelayScaled(900, ct);
+                    continue;
+                }
+
+                // --- Acquired the lock ---
+                w.CurrentLock = @lock;
+                w.State = WorkerState.Holding;
+                w.FencingToken = @lock.FencingToken;
+                w.TtlSeconds = @lock.Ttl > 0 ? @lock.Ttl : _ttlSeconds;
+                w.HoldStartedUtc = DateTimeOffset.UtcNow;
+                w.WorkEndsUtc = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(w.WorkDurationSeconds);
+                w.LeaseExpiresUtc = (@lock.LockLastRenewedAt ?? DateTimeOffset.UtcNow) + TimeSpan.FromSeconds(w.TtlSeconds);
+                w.RenewCount = 0;
+                Log(w, $"ACQUIRED [{w.LockName}] · fencing token {w.FencingToken}", LogLevel.Success);
+                Notify();
+
+                var resource = GetResource(w.LockName);
+                bool renewFailed = false;
+
+                while (DateTimeOffset.UtcNow < w.WorkEndsUtc && w.State == WorkerState.Holding && !ct.IsCancellationRequested)
+                {
+                    // The holder does work by writing to a shared resource, stamped with its
+                    // fencing token. A stale holder's writes are rejected (see ProtectedResource).
+                    bool accepted = resource.TryWrite(w.Name, w.Color, w.FencingToken);
+                    if (!accepted && !w.LockExpiredWhileWorking)
+                    {
+                        Log(w, $"write to [{w.LockName}] REJECTED — fencing token {w.FencingToken} is stale", LogLevel.Error);
+                    }
+
+                    var expiresAt = w.LeaseExpiresUtc!.Value;
+                    if (w.RenewalEnabled)
+                    {
+                        if (DateTimeOffset.UtcNow >= expiresAt - TimeSpan.FromSeconds(1.5))
+                        {
+                            bool renewed = await @lock.TryRenewAsync();
+                            if (renewed)
+                            {
+                                w.RenewCount++;
+                                w.LeaseExpiresUtc = (@lock.LockLastRenewedAt ?? DateTimeOffset.UtcNow) + TimeSpan.FromSeconds(w.TtlSeconds);
+                                Log(w, $"renewed lease on [{w.LockName}] — still working", LogLevel.Info);
+                                Notify();
+                            }
+                            else
+                            {
+                                renewFailed = true;
+                                Log(w, $"lost [{w.LockName}] — renewal failed", LogLevel.Error);
+                                break;
+                            }
+                        }
+                    }
+                    else if (!w.LockExpiredWhileWorking && DateTimeOffset.UtcNow >= expiresAt)
+                    {
+                        w.LockExpiredWhileWorking = true;
+                        w.Status = "lease EXPIRED — still working!";
+                        Log(w, $"lease on [{w.LockName}] EXPIRED but work continues (renewal OFF) — danger!", LogLevel.Error);
+                        Notify();
+                    }
+
+                    await DelayScaled(600, ct);
+                }
+
+                if (w.State == WorkerState.Crashed)
+                {
+                    // Abandon the lock (no release) — Cosmos TTL will delete it.
+                    Log(w, $"CRASHED holding [{w.LockName}] — lock left to expire via TTL (no deadlock)", LogLevel.Error);
+                    w.CurrentLock = null;
+                    w.HoldStartedUtc = null; w.WorkEndsUtc = null; w.LeaseExpiresUtc = null;
+                    w.Running = false;
+                    Notify();
+                    return;
+                }
+
+                if (renewFailed)
+                {
+                    @lock.Dispose();
+                    w.CurrentLock = null;
+                    w.State = WorkerState.Idle;
+                    w.Status = "lost the lock";
+                    w.HoldStartedUtc = null; w.WorkEndsUtc = null; w.LeaseExpiresUtc = null;
+                    Notify();
+                    await DelayScaled(900, ct);
+                    continue;
+                }
+
+                // Work finished — release the lock (delete). If it already expired, this is a no-op.
+                @lock.Dispose();
+                w.CurrentLock = null;
+                w.State = WorkerState.Idle;
+                w.Status = w.LockExpiredWhileWorking ? "finished (but had lost the lock!)" : "released";
+                w.HoldStartedUtc = null; w.WorkEndsUtc = null; w.LeaseExpiresUtc = null;
+                Log(w, $"finished work — released [{w.LockName}]", LogLevel.Info);
+                Notify();
+                await DelayScaled(900, ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // stopping
+        }
+        catch (Exception ex)
+        {
+            Log(w, $"error: {ex.Message}", LogLevel.Error);
+        }
+        finally
+        {
+            try { w.CurrentLock?.Dispose(); } catch { }
+            w.CurrentLock = null;
+            if (w.State != WorkerState.Crashed) { w.State = WorkerState.Idle; }
+            w.Running = false;
+            Notify();
+        }
+    }
+
+    private async Task DelayScaled(int ms, CancellationToken ct)
+    {
+        int scaled = Math.Max(50, (int)(ms / _pace));
+        await Task.Delay(scaled, ct);
+    }
+
+    private Worker? Find(Guid id)
+    {
+        lock (_sync) { return _workers.FirstOrDefault(x => x.Id == id); }
+    }
+
+    private void Log(Worker w, string message, LogLevel level)
+    {
+        lock (_sync)
+        {
+            _log.AddFirst(new LogEntry(DateTimeOffset.UtcNow, w.Name, w.Color, message, level));
+            while (_log.Count > 120) _log.RemoveLast();
+        }
+    }
+
+    private void Notify() => Changed?.Invoke();
+}

--- a/distributed-lock/source/Website/Services/SimulationService.cs
+++ b/distributed-lock/source/Website/Services/SimulationService.cs
@@ -31,6 +31,9 @@ public class SimulationService
     private int _initialized;
     private int _nameCounter;
 
+    private CosmosClient? _sweepClient;
+    private readonly CancellationTokenSource _sweepCts = new();
+
     public IReadOnlyList<string> LockNames { get; } = new[] { "resource-A", "resource-B" };
 
     public event Action? Changed;
@@ -102,20 +105,84 @@ public class SimulationService
 
         try
         {
-            using CosmosClient bootstrap = CosmosClientFactory.Create(_endpoint, _key);
-            Database db = await bootstrap.CreateDatabaseIfNotExistsAsync(_databaseName);
-            await db.CreateContainerIfNotExistsAsync(new ContainerProperties
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+            using (CosmosClient bootstrap = CosmosClientFactory.Create(_endpoint, _key))
             {
-                Id = _containerName,
-                PartitionKeyPath = "/id",
-                DefaultTimeToLive = -1
-            });
+                Database db = await bootstrap.CreateDatabaseIfNotExistsAsync(_databaseName, cancellationToken: cts.Token);
+                await db.CreateContainerIfNotExistsAsync(new ContainerProperties
+                {
+                    Id = _containerName,
+                    PartitionKeyPath = "/id",
+                    DefaultTimeToLive = -1
+                }, cancellationToken: cts.Token);
+            }
+
+            // Simulate Cosmos DB TTL locally. The vNext emulator accepts a TTL but does not
+            // actively delete expired documents, so this sweeper removes locks whose lease has
+            // expired (for example a crashed holder that stopped renewing) — exactly what real
+            // Cosmos TTL does. It uses an ETag so it never removes an actively renewed lock.
+            _sweepClient = CosmosClientFactory.Create(_endpoint, _key);
+            _ = SweepExpiredLocksAsync(_sweepCts.Token);
         }
-        catch
+        catch (Exception ex)
         {
-            // Allow retry on a later call (e.g., transient emulator warmup).
+            // Allow a retry on a later call and surface a clear, actionable message.
             Interlocked.Exchange(ref _initialized, 0);
-            throw;
+            throw new InvalidOperationException(
+                $"Could not reach Azure Cosmos DB at {_endpoint}. If you're running locally, start the emulator with 'docker compose up -d' from the repo root, then click Start all. ({ex.GetType().Name}: {ex.Message})", ex);
+        }
+    }
+
+    private sealed class SweepDoc
+    {
+        [JsonProperty("id")] public string? Id { get; set; }
+        [JsonProperty("lockLastRenewedAt")] public DateTimeOffset? LockLastRenewedAt { get; set; }
+        [JsonProperty("_ttl")] public int Ttl { get; set; }
+        [JsonProperty("_etag")] public string? ETag { get; set; }
+    }
+
+    private async Task SweepExpiredLocksAsync(CancellationToken ct)
+    {
+        Container container = _sweepClient!.GetContainer(_databaseName, _containerName);
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var now = DateTimeOffset.UtcNow;
+                using FeedIterator<SweepDoc> feed = container.GetItemQueryIterator<SweepDoc>(
+                    "SELECT c.id, c.lockLastRenewedAt, c[\"_ttl\"], c[\"_etag\"] FROM c");
+                while (feed.HasMoreResults)
+                {
+                    foreach (SweepDoc doc in await feed.ReadNextAsync(ct))
+                    {
+                        if (doc.Id is null || doc.Ttl <= 0 || doc.LockLastRenewedAt is not { } renewed) continue;
+                        if (now <= renewed.AddSeconds(doc.Ttl)) continue;
+
+                        try
+                        {
+                            await container.DeleteItemAsync<SweepDoc>(doc.Id, new PartitionKey(doc.Id),
+                                new ItemRequestOptions { IfMatchEtag = doc.ETag }, ct);
+                            LogSystem($"lock [{doc.Id}] lease expired (TTL) and was auto-released — no deadlock", LogLevel.Warn);
+                            Notify();
+                        }
+                        catch (CosmosException)
+                        {
+                            // The lock was renewed or already released between the read and delete.
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch
+            {
+                // Transient; try again next tick.
+            }
+
+            try { await Task.Delay(2000, ct); }
+            catch (OperationCanceledException) { return; }
         }
     }
 
@@ -393,6 +460,15 @@ public class SimulationService
         lock (_sync)
         {
             _log.AddFirst(new LogEntry(DateTimeOffset.UtcNow, w.Name, w.Color, message, level));
+            while (_log.Count > 120) _log.RemoveLast();
+        }
+    }
+
+    private void LogSystem(string message, LogLevel level)
+    {
+        lock (_sync)
+        {
+            _log.AddFirst(new LogEntry(DateTimeOffset.UtcNow, "TTL", "#94a3b8", message, level));
             while (_log.Count > 120) _log.RemoveLast();
         }
     }

--- a/distributed-lock/source/Website/Shared/MainLayout.razor
+++ b/distributed-lock/source/Website/Shared/MainLayout.razor
@@ -1,0 +1,3 @@
+@inherits LayoutComponentBase
+
+@Body

--- a/distributed-lock/source/Website/Website.csproj
+++ b/distributed-lock/source/Website/Website.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>DistributedLockWeb</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CosmosDistributedLock\CosmosDistributedLock.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/distributed-lock/source/Website/_Imports.razor
+++ b/distributed-lock/source/Website/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using DistributedLockWeb
+@using DistributedLockWeb.Shared
+@using DistributedLockWeb.Services

--- a/distributed-lock/source/Website/appsettings.json
+++ b/distributed-lock/source/Website/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "CosmosUri": "",
+  "CosmosKey": ""
+}

--- a/distributed-lock/source/Website/wwwroot/css/site.css
+++ b/distributed-lock/source/Website/wwwroot/css/site.css
@@ -1,0 +1,193 @@
+:root {
+    --bg: #0b1120;
+    --bg-2: #0f172a;
+    --card: #131c31;
+    --card-2: #182238;
+    --border: #24304d;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --primary: #38bdf8;
+    --ok: #34d399;
+    --warn: #f59e0b;
+    --err: #fb7185;
+    --shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: radial-gradient(1200px 600px at 20% -10%, #16233f 0%, var(--bg) 55%) fixed;
+    color: var(--text);
+    font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    font-size: 15px;
+    line-height: 1.45;
+}
+
+.app { max-width: 1280px; margin: 0 auto; padding: 24px 20px 60px; }
+
+/* ---------- hero ---------- */
+.hero {
+    display: flex; flex-wrap: wrap; gap: 18px; align-items: center; justify-content: space-between;
+    margin-bottom: 22px;
+}
+.hero-title { display: flex; gap: 16px; align-items: center; }
+.lock-emoji { font-size: 44px; filter: drop-shadow(0 4px 10px rgba(56,189,248,.4)); }
+.hero h1 { margin: 0; font-size: 26px; letter-spacing: .2px; }
+.hero p { margin: 4px 0 0; color: var(--muted); max-width: 620px; }
+.hero em { color: var(--primary); font-style: normal; }
+
+.toolbar { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+.slider-inline { display: flex; flex-direction: column; gap: 2px; font-size: 12px; color: var(--muted); min-width: 130px; }
+.slider-inline strong { color: var(--text); }
+
+/* ---------- buttons ---------- */
+.btn {
+    background: var(--card-2); color: var(--text); border: 1px solid var(--border);
+    padding: 8px 14px; border-radius: 9px; cursor: pointer; font-size: 13px; font-weight: 600;
+    transition: transform .08s ease, border-color .15s ease, background .15s ease;
+}
+.btn:hover { border-color: var(--primary); transform: translateY(-1px); }
+.btn.primary { background: linear-gradient(180deg, #38bdf8, #0ea5e9); color: #05121f; border-color: transparent; }
+.btn.tiny { padding: 5px 10px; font-size: 12px; }
+.btn.danger { color: var(--err); border-color: #4a2434; }
+.btn.danger:hover { border-color: var(--err); }
+.btn.ghost { color: var(--muted); }
+.btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+
+.error-banner {
+    background: #3b1220; border: 1px solid #7f1d3a; color: #fecdd3;
+    padding: 12px 16px; border-radius: 10px; margin-bottom: 18px;
+}
+.error-banner code { background: rgba(255,255,255,.08); padding: 1px 6px; border-radius: 5px; }
+
+/* ---------- workers ---------- */
+.workers { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; margin-bottom: 26px; }
+
+.worker-card {
+    background: linear-gradient(180deg, var(--card), var(--card-2));
+    border: 1px solid var(--border); border-radius: 14px; padding: 14px;
+    box-shadow: var(--shadow); position: relative; overflow: hidden;
+    transition: box-shadow .25s ease, border-color .25s ease, transform .1s ease;
+}
+.worker-card::before {
+    content: ""; position: absolute; inset: 0 0 auto 0; height: 3px; background: var(--accent); opacity: .8;
+}
+.worker-card.state-holding { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent), 0 0 34px -6px var(--accent); }
+.worker-card.state-danger { border-color: var(--err); box-shadow: 0 0 0 1px var(--err), 0 0 34px -6px var(--err); animation: dangerPulse 1s infinite; }
+.worker-card.state-crashed { border-color: #7f1d1d; filter: grayscale(.5) brightness(.8); }
+
+@keyframes dangerPulse { 0%,100% { box-shadow: 0 0 0 1px var(--err), 0 0 26px -8px var(--err); } 50% { box-shadow: 0 0 0 1px var(--err), 0 0 40px -2px var(--err); } }
+
+.worker-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.dot { width: 12px; height: 12px; border-radius: 50%; box-shadow: 0 0 10px var(--accent); }
+.worker-name { font-weight: 700; }
+.state-badge {
+    margin-left: auto; font-size: 11px; font-weight: 700; letter-spacing: .4px; text-transform: uppercase;
+    padding: 3px 8px; border-radius: 999px; background: #1f2a44; color: var(--muted);
+}
+.state-badge.state-holding { background: rgba(52,211,153,.14); color: var(--ok); }
+.state-badge.state-trying { background: rgba(56,189,248,.14); color: var(--primary); }
+.state-badge.state-waiting { background: rgba(245,158,11,.16); color: var(--warn); }
+.state-badge.state-danger, .state-badge.state-crashed { background: rgba(251,113,133,.16); color: var(--err); }
+
+.hold-info { margin-bottom: 10px; }
+.fence { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+.fence strong { color: var(--text); font-size: 14px; }
+.heartbeat { display: inline-block; margin-left: 4px; animation: beat 1s infinite; }
+@keyframes beat { 0%,100% { transform: scale(1); } 25% { transform: scale(1.35); } 40% { transform: scale(1); } }
+
+.lease-bar {
+    position: relative; height: 22px; background: #0b1424; border: 1px solid var(--border);
+    border-radius: 7px; overflow: hidden;
+}
+.lease-fill {
+    height: 100%; background: linear-gradient(90deg, var(--ok), #22d3ee);
+    transition: width .22s linear; box-shadow: 0 0 16px -4px var(--ok);
+}
+.lease-bar.expired .lease-fill { background: var(--err); }
+.lease-text {
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    font-size: 11px; font-weight: 600; color: #04121e; text-shadow: 0 1px 0 rgba(255,255,255,.25);
+}
+.lease-bar.expired .lease-text { color: #fff; text-shadow: none; }
+
+.worker-status { font-size: 12px; color: var(--muted); margin-bottom: 10px; min-height: 16px; }
+
+/* ---------- controls ---------- */
+.controls { display: flex; flex-direction: column; gap: 9px; }
+.ctl { display: flex; flex-direction: column; gap: 3px; font-size: 12px; color: var(--muted); }
+.ctl span strong { color: var(--text); }
+.ctl-row { display: flex; gap: 8px; }
+.mini { flex: 1; display: flex; flex-direction: column; gap: 3px; font-size: 11px; color: var(--muted); }
+.mini select, .worker-card select {
+    background: #0b1424; color: var(--text); border: 1px solid var(--border); border-radius: 7px; padding: 5px 6px; font-size: 12px;
+}
+.switch { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text); cursor: pointer; }
+.switch input { width: 16px; height: 16px; accent-color: var(--primary); }
+
+input[type=range] { width: 100%; accent-color: var(--accent, var(--primary)); }
+
+.btn-row { display: flex; gap: 8px; margin-top: 4px; }
+.btn-row .ghost { margin-left: auto; }
+
+/* ---------- lower: resources + timeline ---------- */
+.lower { display: grid; grid-template-columns: 1.15fr .85fr; gap: 18px; margin-bottom: 26px; }
+@media (max-width: 900px) { .lower { grid-template-columns: 1fr; } .workers { grid-template-columns: 1fr; } }
+
+h2 { font-size: 15px; margin: 0 0 12px; letter-spacing: .3px; }
+h2 .hint { font-weight: 400; color: var(--muted); font-size: 12px; margin-left: 6px; }
+
+.resource-card {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 14px; margin-bottom: 14px;
+}
+.resource-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 10px; }
+.res-name { font-weight: 700; font-family: ui-monospace, "Cascadia Code", monospace; }
+.res-holder { font-size: 12px; }
+.res-stats { display: flex; gap: 10px; margin-bottom: 8px; }
+.stat { flex: 1; background: #0d1626; border: 1px solid var(--border); border-radius: 9px; padding: 8px; text-align: center; }
+.stat strong { display: block; font-size: 20px; }
+.stat span { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .4px; }
+.stat.ok strong { color: var(--ok); }
+.stat.bad strong { color: var(--err); }
+.stat.flash { animation: flashBad .5s ease; }
+@keyframes flashBad { 0% { background: rgba(251,113,133,.35); } 100% { background: #0d1626; } }
+
+.reject-note {
+    font-size: 12px; color: #fecdd3; background: rgba(251,113,133,.08);
+    border-left: 3px solid var(--err); border-radius: 6px; padding: 8px 10px; margin-bottom: 8px;
+}
+.lock-doc {
+    background: #050c18; border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; margin: 0;
+    font-family: ui-monospace, "Cascadia Code", monospace; font-size: 12px; color: #7dd3fc; overflow-x: auto;
+}
+
+/* ---------- timeline ---------- */
+.timeline { }
+.log {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 6px;
+    height: 360px; overflow-y: auto; font-family: ui-monospace, "Cascadia Code", monospace; font-size: 12px;
+}
+.log-row { display: flex; gap: 8px; padding: 3px 8px; border-radius: 6px; }
+.log-row:hover { background: rgba(255,255,255,.03); }
+.log-time { color: #64748b; }
+.log-worker { font-weight: 700; min-width: 66px; }
+.log-msg { color: var(--text); }
+.log-row.lvl-ok .log-msg { color: var(--ok); }
+.log-row.lvl-warn .log-msg { color: var(--warn); }
+.log-row.lvl-err .log-msg { color: var(--err); }
+
+/* ---------- explain ---------- */
+.explain { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 16px 20px; }
+.explain ul { margin: 0; padding-left: 18px; }
+.explain li { margin: 7px 0; color: var(--muted); }
+.explain li strong { color: var(--text); }
+.explain code, .hero code, .error-banner code { font-family: ui-monospace, monospace; background: rgba(255,255,255,.06); padding: 1px 6px; border-radius: 5px; color: #7dd3fc; }
+
+/* ---------- blazor error ---------- */
+#blazor-error-ui {
+    background: #7f1d1d; color: #fff; bottom: 0; box-shadow: 0 -1px 2px rgba(0,0,0,.2);
+    display: none; left: 0; padding: 0.8rem 1.4rem; position: fixed; width: 100%; z-index: 1000;
+}
+#blazor-error-ui .dismiss { cursor: pointer; position: absolute; right: 0.75rem; top: 0.5rem; }

--- a/distributed-lock/source/Website/wwwroot/css/site.css
+++ b/distributed-lock/source/Website/wwwroot/css/site.css
@@ -62,6 +62,17 @@ html, body {
 }
 .error-banner code { background: rgba(255,255,255,.08); padding: 1px 6px; border-radius: 5px; }
 
+.info-banner {
+    background: #0c2a3a; border: 1px solid #0e7490; color: #a5f3fc;
+    padding: 12px 16px; border-radius: 10px; margin-bottom: 18px;
+    display: flex; align-items: center; gap: 10px;
+}
+.info-banner::before {
+    content: ""; width: 14px; height: 14px; border-radius: 50%;
+    border: 2px solid #22d3ee; border-top-color: transparent; animation: spin .8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
 /* ---------- workers ---------- */
 .workers { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; margin-bottom: 26px; }
 


### PR DESCRIPTION
Adds an **interactive web front end** for the distributed-lock sample — a visually engaging way to *see* how the lock works and why it's useful. It's a **Blazor Server (.NET 10)** app where several on-screen "workers" compete for **real** Azure Cosmos DB locks via the `CosmosDistributedLock` library; the UI mirrors live Cosmos state in real time.

## Interactive features (all of #1–#8)
- **Work-duration slider** per worker — set work shorter/longer than the TTL and watch the keep-alive hold the lock.
- **Auto-renew toggle** + a **fencing-token "protected resource"** that only accepts the highest token — turn renewal off, let work exceed the TTL, and watch the stale holder's writes get **rejected**. This is the payoff that shows *why fencing tokens exist*.
- **💥 Crash a holder** — it stops without releasing; the lock auto-releases via **TTL** (no deadlock).
- **Try vs Wait(timeout)** acquire modes; **multiple lock names** (granularity — different names don't block each other); live **TTL** and **retry-pace** sliders; **add/remove** workers.
- Live **lease countdown bars**, **heartbeat** pulses, a color-coded **event timeline**, and the synthesized **lock document**.

## Library hooks (backward compatible)
`CosmosDistributedLock` gains an optional non-auto-renew acquire, a public `TryRenewAsync`, a `Renewed` event, TTL-countdown properties, and a per-acquire TTL override — so the web app can drive/observe renewal and demonstrate the *no-renewal* failure mode. Production callers are unaffected (automatic keep-alive stays the default).

## azd
The distributed-lock template now **deploys the web front end to App Service** (reusing the shared `web-app.bicep`) over the keyless, serverless Cosmos account; the console app remains as an optional local driver.

## Validation (real, against the vNext emulator)
- The site boots, prerenders the workers, and publishes cleanly (no dev secrets in the publish output).
- With the workers running, **real lock documents are created and deleted** in the `Locks` container with correct **mutual exclusion** — one holder at a time, with release gaps observed between holders.
- Library + web build clean.

> Note: I validated the core end-to-end (real locks, mutual exclusion, acquire/release against Cosmos) plus build/publish; the renewal and fencing-token behaviors reuse primitives already validated by the console demo and integration tests. The richest way to exercise the UI is to open it and click through the "Things to try" list.

This is v1 — happy to iterate on the visuals or add more scenarios.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>