### PR TITLE
Fix Blazor static assets in Production + emulator defaults for sample web apps

### DIFF
--- a/distributed-counter/source/Visualizer/Program.cs
+++ b/distributed-counter/source/Visualizer/Program.cs
@@ -32,6 +32,11 @@ namespace DistributedCounterDashboard
             })
             .ConfigureWebHostDefaults(webBuilder =>
             {
+                // Serve the Blazor framework static assets (e.g. _framework/blazor.server.js) in ALL
+                // environments. Without this they are only served in Development, so a published /
+                // deployed (Production) build returns 404 for blazor.server.js and the interactive
+                // dashboard never connects.
+                webBuilder.UseStaticWebAssets();
                 webBuilder.UseStartup<Startup>();
             });
     }

--- a/distributed-counter/source/Visualizer/Startup.cs
+++ b/distributed-counter/source/Visualizer/Startup.cs
@@ -38,10 +38,22 @@ namespace DistributedCounterDashboard
         private static DistributedCounterManagementService InitializeDistributedCounterManagementServiceAsync(IConfiguration configuration)
         {
 
-            string endpoint = configuration["CosmosUri"];
+            string endpoint = configuration["CosmosUri"] ?? string.Empty;
             string key = configuration["CosmosKey"] ?? string.Empty;
             string databaseName = configuration["CosmosDatabase"];
             string containerName = configuration["CosmosContainer"];
+
+            // Default to the local Azure Cosmos DB emulator when nothing is configured, so the site
+            // runs with zero setup once the emulator is started (`docker compose up` from the repo
+            // root). In Azure, azd sets CosmosUri to the provisioned account.
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                endpoint = "https://localhost:8081";
+                if (string.IsNullOrEmpty(key))
+                {
+                    key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+                }
+            }
 
             DistributedCounterManagementService dcms =  new DistributedCounterManagementService(endpoint,key,databaseName,containerName);
 

--- a/document-versioning/source/website/Program.cs
+++ b/document-versioning/source/website/Program.cs
@@ -53,9 +53,24 @@ static class ProgramExtensions
             }
             else
             {
+                string endpoint = cosmosOptions.Value?.CosmosUri ?? string.Empty;
+                string? key = cosmosOptions.Value?.CosmosKey;
+
+                // Default to the local Azure Cosmos DB emulator when nothing is configured, so the
+                // site runs with zero setup once the emulator is started (`docker compose up` from
+                // the repo root). In Azure, azd sets CosmosUri to the provisioned account.
+                if (string.IsNullOrWhiteSpace(endpoint))
+                {
+                    endpoint = "https://localhost:8081";
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+                    }
+                }
+
                 return new CosmosDb(
-                    cosmosUri: cosmosOptions.Value?.CosmosUri ?? string.Empty,
-                    cosmosKey: cosmosOptions.Value?.CosmosKey,
+                    cosmosUri: endpoint,
+                    cosmosKey: key,
                     database: cosmosOptions.Value?.Database ?? string.Empty,
                     currentOrderContainer: cosmosOptions.Value?.CurrentOrderContainer ?? string.Empty,
                     historicalOrderContainer: cosmosOptions.Value?.HistoricalOrderContainer ?? string.Empty,

--- a/schema-versioning/source/website/Program.cs
+++ b/schema-versioning/source/website/Program.cs
@@ -46,9 +46,24 @@ static class ProgramExtensions
             }
             else
             {
+                string endpoint = cosmosOptions.Value?.CosmosUri ?? string.Empty;
+                string? key = cosmosOptions.Value?.CosmosKey;
+
+                // Default to the local Azure Cosmos DB emulator when nothing is configured, so the
+                // site runs with zero setup once the emulator is started (`docker compose up` from
+                // the repo root). In Azure, azd sets CosmosUri to the provisioned account.
+                if (string.IsNullOrWhiteSpace(endpoint))
+                {
+                    endpoint = "https://localhost:8081";
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+                    }
+                }
+
                 return new CosmosDbService(
-                    cosmosUri: cosmosOptions.Value?.CosmosUri ?? string.Empty,
-                    cosmosKey: cosmosOptions.Value?.CosmosKey,
+                    cosmosUri: endpoint,
+                    cosmosKey: key,
                     databaseName: cosmosOptions.Value?.DatabaseName ?? string.Empty,
                     containerName: cosmosOptions.Value?.ContainerName ?? string.Empty,
                     partitionKeyPath: cosmosOptions.Value?.PartitionKeyPath ?? string.Empty


### PR DESCRIPTION
Applies the same two fixes from the distributed-lock website (#93) to the other sample web front ends, after verifying which ones shared the bug.

## What was wrong
The **distributed-counter Visualizer** is a classic Blazor Server app with the exact same defect distributed-lock had: in a published/Production build, `/_framework/blazor.server.js` returns **404**, so the Blazor circuit never connects — the page loads but nothing is interactive. Verified via HTTP and Playwright (404 before, 200 after; zero console errors after).

`document-versioning` and `schema-versioning` are server-rendered Razor Pages (no `blazor.server.js`), so they were **not** affected by the static-asset bug.

## Changes
- **Visualizer**: `webBuilder.UseStaticWebAssets()` so the Blazor framework assets are served in all environments.
- **All three web apps**: default to the local Cosmos DB emulator (`https://localhost:8081` + well-known key) when no `CosmosUri` is configured, so they run with zero setup after `docker compose up`. In Azure, azd sets `CosmosUri` and this fallback is skipped.

## Verification
Built all three (Release). Ran each in Production against the emulator with **empty config** and confirmed:
- Visualizer: `/` = 200, `blazor.server.js` = 200, circuit connects (0 console 404s).
- document-versioning: `/` = 200.
- schema-versioning: `/` = 200.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
