### PR TITLE
Add Loop-Safe Change Feed pattern (closes #67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Discover how to manage document versioning effectively within Azure Cosmos DB. T
 
 Uncover the power of event sourcing for building applications that maintain a history of changes as a sequence of events. Explore the `event-sourcing` folder for in-depth instructions. Read more about this design pattern in this [blog post](https://aka.ms/cosmosdbdesignpatterns/event-sourcing).
 
+### [Loop-Safe Change Feed Enrichment](/loop-safe-change-feed/)
+
+Learn how to enrich documents **in place** from the change feed — deriving a value and writing it back onto the same document — without creating an infinite loop, by hashing the source so the echo of your own write is skipped. See the `loop-safe-change-feed` folder for a Change Feed Processor implementation and an interactive web front end.
+
 ### [Materialized View](/materialized-view/)
 
 Learn how to create and manage materialized views to efficiently retrieve precomputed data from Azure Cosmos DB. Refer to the `materialized-view` folder for implementation details. Read more about this design pattern in this [blog post](https://aka.ms/cosmosdbdesignpatterns/materialized-view).  

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Discover how to manage document versioning effectively within Azure Cosmos DB. T
 
 Uncover the power of event sourcing for building applications that maintain a history of changes as a sequence of events. Explore the `event-sourcing` folder for in-depth instructions. Read more about this design pattern in this [blog post](https://aka.ms/cosmosdbdesignpatterns/event-sourcing).
 
-### [Loop-Safe Change Feed Enrichment](/loop-safe-change-feed/)
+### [Loop-Safe Change Feed](/loop-safe-change-feed/)
 
 Learn how to enrich documents **in place** from the change feed — deriving a value and writing it back onto the same document — without creating an infinite loop, by hashing the source so the echo of your own write is skipped. See the `loop-safe-change-feed` folder for a Change Feed Processor implementation and an interactive web front end.
 

--- a/loop-safe-change-feed/README.md
+++ b/loop-safe-change-feed/README.md
@@ -1,0 +1,146 @@
+---
+page_type: sample
+languages:
+- csharp
+products:
+- azure-cosmos-db
+name: |
+  Azure Cosmos DB design pattern: Loop-Safe Change Feed Enrichment
+urlFragment: loop-safe-change-feed
+description: Enrich documents in place from the Azure Cosmos DB change feed without creating an infinite loop, by hashing the source so the echo of your own write is skipped.
+---
+
+# Azure Cosmos DB design pattern: Loop-Safe Change Feed Enrichment
+
+A very common need is to **derive** something from a document and store the result **on the same document** — a search-normalized field, a translation, a sentiment score, an embedding vector, or (in this sample) a small **identicon** image. The Azure Cosmos DB [change feed](https://learn.microsoft.com/azure/cosmos-db/nosql/change-feed-processor) is the natural way to do this: it hands you every create and update, you compute the derived value, and you write it back.
+
+The catch: **writing back to the same container you're reading from re-triggers the change feed.** Your write is itself a change, which fires the processor again, which writes again… an **infinite loop** that burns request units forever.
+
+This sample shows the standard way to make that safe. It stores a **hash of the source** on the document. Every time the change feed delivers a document, the processor recomputes the source hash and compares it to the stored one:
+
+- **Hashes differ** (or none is stored) → the source really changed. Compute the derived value, store it **plus the new hash**, and write.
+- **Hashes match** → this is the *echo of our own write*. Skip it. Because we skip, there is no second write, so the loop stops after exactly one enrichment.
+
+This sample demonstrates:
+
+- ✅ In-place enrichment driven by the **Change Feed Processor** (no Azure Functions required)
+- ✅ A **hash of the source** as the loop guard, so writing back can't run away
+- ✅ **Idempotent** processing — the same change delivered twice is a no-op (change feed is at-least-once)
+- ✅ **Optimistic concurrency** (ETag) so a concurrent user edit is never clobbered
+- ✅ An interactive web front end that makes the "one enrich, then one skip" behavior visible
+
+> **Credit:** the mechanism in this sample is a generalized, dependency-free adaptation of the [Azure Cosmos DB Embeddings Generator](https://github.com/AzureCosmosDB/cosmos-embeddings-generator), which uses the same source-hash technique to avoid loops while generating Azure OpenAI embeddings in place.
+
+## Common scenario
+
+Any time you want a document to carry a value *derived from its own contents*, and you want that value kept up to date automatically as the contents change:
+
+1. **AI enrichment** — generate an embedding vector, a summary, a translation, or a classification for a text field and store it alongside the text (this is exactly what the embeddings-generator does).
+2. **Search preparation** — derive a lowercased, accent-stripped, tokenized field so queries can match case-insensitively.
+3. **Denormalized/derived fields** — a slug from a title, a full name from parts, a geohash from coordinates, a risk score from several fields.
+4. **Media/metadata** — here, a deterministic **identicon** image derived from the text.
+
+In every case the tricky part is the same — enriching *in place* without looping — and the solution is the same: hash the source.
+
+## Sample implementation
+
+The derived value in this sample is an **identicon**: a GitHub-style 5×5 symmetric avatar rendered as an inline SVG, generated deterministically from the source hash. It's a great fit for teaching the pattern because the picture **is** a visualization of the hash — when you edit the text, the hash changes, so the avatar visibly changes; when nothing meaningful changed, the avatar stays the same and the change is skipped.
+
+The core logic lives in `source/Enrichment` and is deliberately tiny and dependency-free:
+
+- **`SourceHasher`** — SHA-256 of the source property's value.
+- **`IdenticonGenerator`** — turns a hash into an SVG string (pure string/crypto; no packages). This is the *pluggable* step: replace it with a call to Azure OpenAI, a translator, a classifier, etc.
+- **`DocumentEnricher`** — the decision, isolated from Cosmos DB so it's trivial to reason about:
+
+  ```csharp
+  string newHash = SourceHasher.Compute(document[options.SourceProperty]?.ToString());
+  string? storedHash = document[options.HashProperty]?.ToString();
+
+  if (newHash == storedHash)
+      return EnrichmentDecision.Skipped(storedHash);   // echo of our own write — stop the loop
+
+  document[options.EnrichedProperty] = IdenticonGenerator.ToSvg(newHash);
+  document[options.HashProperty] = newHash;            // hash covers the SOURCE only
+  return EnrichmentDecision.Enriched(storedHash, newHash);
+  ```
+
+- **`ChangeFeedEnrichmentProcessor`** — hosts a Cosmos DB Change Feed Processor (with a **lease** container) on the `Documents` container and applies `DocumentEnricher` to each change, writing back with an **ETag** check.
+
+The single most important rule: **the hash covers the source property only — never the derived value or the hash itself.** That's what guarantees the write-back doesn't change the hash, so the echo is always recognized and skipped.
+
+Every property name is configurable (`EnrichmentOptions`), so the pattern is generic:
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `SourceProperty` | `text` | the input the derived value is computed from |
+| `EnrichedProperty` | `identicon` | where the derived value is stored |
+| `HashProperty` | `sourceHash` | the loop-guard hash of the source |
+
+This sample ships two ways to explore the pattern:
+
+- An **interactive web front end** (`source/Website`) — add and edit documents, watch each identicon appear a moment after you save, and follow a live **change feed activity** timeline showing one `ENRICHED` per edit followed by exactly one `SKIPPED` echo. A **writes-vs-skips** counter stays in lock-step, which *is* the loop being bounded.
+- A **console processor** (`source/Processor`) — starts the processor and makes a few edits, printing the same enrich/skip sequence and a final summary. A quick, scriptable way to see the mechanism.
+
+## Getting the code
+
+### Using Terminal or VS Code
+
+Directions for installing pre-requisites and cloning this repository are in the [root README](../README.md#getting-started).
+
+## Set up application configuration
+
+Each app reads `CosmosUri` (and optionally `CosmosKey`) from configuration. See [Configuration and authentication](../README.md#configuration-and-authentication) in the root README. When nothing is configured, both apps **default to the local emulator** (`https://localhost:8081`), so they run with zero setup.
+
+## Run the demo locally
+
+Start the local emulator first (see the [root README](../README.md#run-locally-with-the-emulator-default)), or point at your own account:
+
+```bash
+docker compose up -d
+```
+
+### Interactive web front end (recommended)
+
+```bash
+cd source/Website
+dotnet run
+```
+
+Open the URL it prints. Add a document with some text and click **Add** — a moment later its colorful identicon appears (the processor enriched it). Now edit the text and click **Save**: the identicon changes, and the timeline shows a new `ENRICHED` followed by a `SKIPPED`. Notice the **enrichment writes** and **skipped echoes** counters climbing together — one of each per edit. That lock-step is the loop being broken instead of running away.
+
+### Console processor
+
+```bash
+cd source/Processor
+dotnet run
+```
+
+The console starts the processor and makes four source edits. Watch each edit produce one `ENRICHED` (a write-back) and one `SKIPPED` (the echo), then a summary confirming the change feed didn't loop.
+
+## (Optional) Deploy and run in Azure with `azd`
+
+The steps above run the sample **all-local**. To run the **all-Azure** way — the web front end hosted in Azure over a keyless Cosmos DB account — this pattern includes an [Azure Developer CLI (`azd`)](https://aka.ms/azd) template. Running locally is unchanged; the deployment files (`azure.yaml`, `infra/`) have no effect unless you run `azd up`.
+
+It provisions and deploys, intentionally minimal and cheap:
+
+- An **App Service** web app (Basic **B1**, **Always On**) that hosts the Change Feed processor in-process and serves the front end.
+- A **serverless** Azure Cosmos DB account with local (key) authentication **disabled**, with the `EnrichDB` database and the `Documents` and `leases` containers pre-created.
+- The web app reaches Cosmos DB **keyless**, via a **user-assigned managed identity** — no keys or connection strings are stored anywhere. The deploying user is also granted data access so you can run the console processor locally against the same account.
+
+### Deploy
+
+From the `loop-safe-change-feed` folder:
+
+```bash
+azd up
+```
+
+### Clean up
+
+```bash
+azd down
+```
+
+## Summary
+
+Enriching documents in place from the change feed is powerful but has one sharp edge: writing to the container you read from re-triggers the feed. Storing a **hash of the source** and skipping changes whose hash is unchanged turns that endless loop into exactly one write per real edit — and, as a bonus, makes processing idempotent. Swap the identicon step for embeddings, translation, or any other enrichment and the loop-safety guarantee still holds.

--- a/loop-safe-change-feed/README.md
+++ b/loop-safe-change-feed/README.md
@@ -5,12 +5,12 @@ languages:
 products:
 - azure-cosmos-db
 name: |
-  Azure Cosmos DB design pattern: Loop-Safe Change Feed Enrichment
+  Azure Cosmos DB design pattern: Loop-Safe Change Feed
 urlFragment: loop-safe-change-feed
 description: Enrich documents in place from the Azure Cosmos DB change feed without creating an infinite loop, by hashing the source so the echo of your own write is skipped.
 ---
 
-# Azure Cosmos DB design pattern: Loop-Safe Change Feed Enrichment
+# Azure Cosmos DB design pattern: Loop-Safe Change Feed
 
 A very common need is to **derive** something from a document and store the result **on the same document** — a search-normalized field, a translation, a sentiment score, an embedding vector, or (in this sample) a small **identicon** image. The Azure Cosmos DB [change feed](https://learn.microsoft.com/azure/cosmos-db/nosql/change-feed-processor) is the natural way to do this: it hands you every create and update, you compute the derived value, and you write it back.
 

--- a/loop-safe-change-feed/azure.yaml
+++ b/loop-safe-change-feed/azure.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: cosmos-db-design-patterns-loop-safe-change-feed
+metadata:
+  template: cosmos-db-design-patterns-loop-safe-change-feed
+# azd deploys the interactive web front end to App Service. It hosts the Change Feed processor
+# in-process (App Service runs with "Always On"). The console app under source/Processor is an
+# optional local driver you can run with `dotnet run` against the same provisioned (keyless)
+# Cosmos account.
+services:
+  web:
+    project: ./source/Website
+    language: dotnet
+    host: appservice

--- a/loop-safe-change-feed/infra/main.bicep
+++ b/loop-safe-change-feed/infra/main.bicep
@@ -1,0 +1,39 @@
+targetScope = 'subscription'
+
+metadata description = 'Deploys the loop-safe-change-feed sample: a serverless, keyless Azure Cosmos DB account plus an App Service web front end that hosts an in-process Change Feed processor. The deploying user is also granted data-plane access so the optional console processor can be run locally.'
+
+@minLength(1)
+@description('Name of the azd environment; used to name the resource group.')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources.')
+param location string
+
+@description('Optional. Principal ID of the deploying user (provided automatically by azd), granted Cosmos data access for local runs.')
+param principalId string = ''
+
+var tags = {
+  'azd-env-name': environmentName
+}
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module resources 'resources.bicep' = {
+  scope: resourceGroup
+  name: 'resources'
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    principalId: principalId
+  }
+}
+
+output AZURE_COSMOS_ENDPOINT string = resources.outputs.cosmosEndpoint
+output SERVICE_WEB_URL string = resources.outputs.webUrl

--- a/loop-safe-change-feed/infra/main.parameters.json
+++ b/loop-safe-change-feed/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "principalId": {
+      "value": "${AZURE_PRINCIPAL_ID}"
+    }
+  }
+}

--- a/loop-safe-change-feed/infra/resources.bicep
+++ b/loop-safe-change-feed/infra/resources.bicep
@@ -1,0 +1,70 @@
+metadata description = 'Resources for the loop-safe-change-feed sample: an App Service web front end (keyless, via managed identity) that hosts an in-process Change Feed processor over a serverless, keyless Azure Cosmos DB account. Reuses the shared web-app and secure-cosmos modules. The account pre-creates the Documents container (source + in-place enrichment target) and a leases container for the processor.'
+
+@description('Location for all resources.')
+param location string
+
+@description('Tags to apply to all resources.')
+param tags object = {}
+
+@description('Short unique token used to name resources.')
+param resourceToken string
+
+@description('Optional. Principal ID of the user running the deployment, granted Cosmos data access for local runs (e.g. the console processor).')
+param principalId string = ''
+
+// Interactive web front end + user-assigned identity (shared module). It hosts the Change Feed
+// processor in-process, so it needs "Always On". The Cosmos endpoint is derived from the account
+// name to avoid a dependency cycle (the Cosmos account grants access to this app's identity).
+module web '../../infra/core/web-app.bicep' = {
+  name: 'web-app'
+  params: {
+    name: 'web-${resourceToken}'
+    location: location
+    tags: union(tags, { 'azd-service-name': 'web' })
+    alwaysOn: true
+    appSettings: [
+      {
+        name: 'CosmosUri'
+        value: 'https://cosmos-${resourceToken}.documents.azure.com:443/'
+      }
+    ]
+  }
+}
+
+// Serverless, keyless Cosmos DB with the sample's database and containers pre-created and
+// data-plane access granted to the web app's identity (and the deploying user, who can run the
+// console processor). The leases container is required by the Change Feed processor.
+module cosmos '../../infra/core/secure-cosmos.bicep' = {
+  name: 'secure-cosmos'
+  params: {
+    name: 'cosmos-${resourceToken}'
+    location: location
+    tags: tags
+    databases: [
+      {
+        name: 'EnrichDB'
+      }
+    ]
+    containers: [
+      {
+        databaseName: 'EnrichDB'
+        name: 'Documents'
+        partitionKey: '/id'
+      }
+      {
+        databaseName: 'EnrichDB'
+        name: 'leases'
+        partitionKey: '/id'
+      }
+    ]
+    dataContributorPrincipalIds: empty(principalId)
+      ? [ web.outputs.identityPrincipalId ]
+      : [ web.outputs.identityPrincipalId, principalId ]
+  }
+}
+
+@description('The Cosmos DB document endpoint.')
+output cosmosEndpoint string = cosmos.outputs.endpoint
+
+@description('The deployed web front end URL.')
+output webUrl string = web.outputs.url

--- a/loop-safe-change-feed/source/Enrichment/ChangeFeedEnrichmentProcessor.cs
+++ b/loop-safe-change-feed/source/Enrichment/ChangeFeedEnrichmentProcessor.cs
@@ -1,0 +1,117 @@
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// Hosts an Azure Cosmos DB <b>Change Feed Processor</b> (no Azure Functions required) that reads
+/// changes from a container and writes the enriched result back to the <b>same</b> container. The
+/// naive version of that would loop forever, because each write is itself a change. The loop is
+/// broken by <see cref="DocumentEnricher"/>: the echo of our own write recomputes the same source
+/// hash, matches the stored hash, and is skipped.
+/// </summary>
+public sealed class ChangeFeedEnrichmentProcessor : IAsyncDisposable
+{
+    private readonly Container _container;
+    private readonly Container _leaseContainer;
+    private readonly DocumentEnricher _enricher;
+    private readonly EnrichmentOptions _options;
+
+    private ChangeFeedProcessor? _processor;
+    private long _writes;
+    private long _skips;
+
+    /// <summary>Raised for every document delivered by the change feed.</summary>
+    public event Action<ProcessedChange>? Processed;
+
+    public long Writes => Interlocked.Read(ref _writes);
+    public long Skips => Interlocked.Read(ref _skips);
+
+    public ChangeFeedEnrichmentProcessor(CosmosClient client, EnrichmentOptions options)
+    {
+        _options = options;
+        _container = client.GetContainer(options.DatabaseName, options.ContainerName);
+        _leaseContainer = client.GetContainer(options.DatabaseName, options.LeaseContainerName);
+        _enricher = new DocumentEnricher(options);
+    }
+
+    /// <summary>Starts processing. Reads existing documents too, so pre-created data is enriched.</summary>
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        _processor = _container
+            .GetChangeFeedProcessorBuilder<JObject>(_options.ProcessorName, HandleChangesAsync)
+            .WithInstanceName($"host-{Guid.NewGuid():N}")
+            .WithLeaseContainer(_leaseContainer)
+            .WithStartTime(DateTime.MinValue.ToUniversalTime())
+            .WithPollInterval(TimeSpan.FromSeconds(1))
+            .Build();
+
+        await _processor.StartAsync();
+    }
+
+    private async Task HandleChangesAsync(
+        IReadOnlyCollection<JObject> changes,
+        CancellationToken cancellationToken)
+    {
+        foreach (JObject document in changes)
+        {
+            string id = document["id"]?.ToString() ?? string.Empty;
+            if (id.Length == 0)
+            {
+                continue;
+            }
+
+            EnrichmentDecision decision = _enricher.Evaluate(document);
+
+            if (!decision.ShouldWrite)
+            {
+                long skips = Interlocked.Increment(ref _skips);
+                Raise(new ProcessedChange(id, EnrichmentKind.Skipped, decision.OldHash, decision.NewHash,
+                    null, Writes, skips, DateTimeOffset.UtcNow));
+                continue;
+            }
+
+            try
+            {
+                // Optimistic concurrency: if the user edited the source again between the feed read
+                // and this write, the ETag no longer matches, so we skip and let the newer change
+                // (already queued in the feed) re-trigger enrichment with the correct source.
+                await _container.ReplaceItemAsync(
+                    document,
+                    id,
+                    new PartitionKey(id),
+                    new ItemRequestOptions { IfMatchEtag = document["_etag"]?.ToString() },
+                    cancellationToken);
+
+                long writes = Interlocked.Increment(ref _writes);
+                Raise(new ProcessedChange(id, EnrichmentKind.Enriched, decision.OldHash, decision.NewHash,
+                    document[_options.SourceProperty]?.ToString(), writes, Skips, DateTimeOffset.UtcNow));
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+            {
+                Raise(new ProcessedChange(id, EnrichmentKind.Superseded, decision.OldHash, decision.NewHash,
+                    null, Writes, Skips, DateTimeOffset.UtcNow));
+            }
+        }
+    }
+
+    private void Raise(ProcessedChange change)
+    {
+        try
+        {
+            Processed?.Invoke(change);
+        }
+        catch
+        {
+            // A misbehaving observer must never break change feed processing.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_processor is not null)
+        {
+            await _processor.StopAsync();
+        }
+    }
+}

--- a/loop-safe-change-feed/source/Enrichment/CosmosClientFactory.cs
+++ b/loop-safe-change-feed/source/Enrichment/CosmosClientFactory.cs
@@ -1,0 +1,33 @@
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// Builds a <see cref="CosmosClient"/> the same way as the rest of this repository:
+/// keyless (DefaultAzureCredential) when no key is supplied, or key-based otherwise. When the
+/// endpoint is the local emulator (localhost), it uses Gateway mode and accepts the emulator's
+/// self-signed certificate — this only ever applies to a local emulator endpoint.
+/// </summary>
+public static class CosmosClientFactory
+{
+    public static CosmosClient Create(string cosmosEndpoint, string? cosmosKey)
+    {
+        CosmosClientOptions? clientOptions = null;
+        if (!string.IsNullOrEmpty(cosmosEndpoint) && new Uri(cosmosEndpoint).Host is "localhost" or "127.0.0.1")
+        {
+            clientOptions = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                HttpClientFactory = () => new HttpClient(new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                })
+            };
+        }
+
+        return string.IsNullOrEmpty(cosmosKey)
+            ? new CosmosClient(cosmosEndpoint, new DefaultAzureCredential(), clientOptions)
+            : new CosmosClient(cosmosEndpoint, cosmosKey, clientOptions);
+    }
+}

--- a/loop-safe-change-feed/source/Enrichment/DocumentEnricher.cs
+++ b/loop-safe-change-feed/source/Enrichment/DocumentEnricher.cs
@@ -1,0 +1,82 @@
+using Newtonsoft.Json.Linq;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>The kind of action the pattern took (or would take) for a document.</summary>
+public enum EnrichmentKind
+{
+    /// <summary>The source changed: the derived value and hash were (re)computed and written.</summary>
+    Enriched,
+
+    /// <summary>The source hash matched the stored hash, so nothing was written (loop broken).</summary>
+    Skipped,
+
+    /// <summary>A concurrent update superseded this change; the newer version re-triggers the feed.</summary>
+    Superseded,
+}
+
+/// <summary>The outcome of evaluating a single document against the enrichment rule.</summary>
+public sealed class EnrichmentDecision
+{
+    private EnrichmentDecision(bool shouldWrite, EnrichmentKind kind, string? oldHash, string? newHash)
+    {
+        ShouldWrite = shouldWrite;
+        Kind = kind;
+        OldHash = oldHash;
+        NewHash = newHash;
+    }
+
+    /// <summary>True when the source changed and the document must be written back.</summary>
+    public bool ShouldWrite { get; }
+
+    public EnrichmentKind Kind { get; }
+
+    /// <summary>The hash previously stored on the document (null on first sight).</summary>
+    public string? OldHash { get; }
+
+    /// <summary>The freshly computed source hash.</summary>
+    public string? NewHash { get; }
+
+    internal static EnrichmentDecision Enriched(string? oldHash, string newHash) =>
+        new(true, EnrichmentKind.Enriched, oldHash, newHash);
+
+    internal static EnrichmentDecision Skipped(string? hash) =>
+        new(false, EnrichmentKind.Skipped, hash, hash);
+}
+
+/// <summary>
+/// The heart of the pattern, isolated from Cosmos DB so it is trivial to reason about and test.
+/// It compares the current source hash to the one stored on the document:
+/// <list type="bullet">
+///   <item>hashes differ (or none stored) → compute the derived value + new hash in place, write.</item>
+///   <item>hashes match → skip. This is the echo of our own write, so writing again would loop.</item>
+/// </list>
+/// The hash is taken over the source property ONLY — never the derived value or the hash itself —
+/// so that writing the derived value does not change the hash and therefore cannot re-trigger work.
+/// </summary>
+public sealed class DocumentEnricher
+{
+    private readonly EnrichmentOptions _options;
+
+    public DocumentEnricher(EnrichmentOptions options) => _options = options;
+
+    /// <summary>
+    /// Evaluates <paramref name="document"/> and, when the source changed, mutates it in place by
+    /// setting the enriched property and the stored hash. Returns what was decided.
+    /// </summary>
+    public EnrichmentDecision Evaluate(JObject document)
+    {
+        string? sourceValue = document[_options.SourceProperty]?.ToString();
+        string newHash = SourceHasher.Compute(sourceValue);
+        string? storedHash = document[_options.HashProperty]?.ToString();
+
+        if (string.Equals(newHash, storedHash, StringComparison.Ordinal))
+        {
+            return EnrichmentDecision.Skipped(storedHash);
+        }
+
+        document[_options.EnrichedProperty] = IdenticonGenerator.ToSvg(newHash);
+        document[_options.HashProperty] = newHash;
+        return EnrichmentDecision.Enriched(storedHash, newHash);
+    }
+}

--- a/loop-safe-change-feed/source/Enrichment/Enrichment.csproj
+++ b/loop-safe-change-feed/source/Enrichment/Enrichment.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Cosmos.ChangeFeedEnrichment</RootNamespace>
+    <AssemblyName>Cosmos.ChangeFeedEnrichment</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.*" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/loop-safe-change-feed/source/Enrichment/EnrichmentBootstrapper.cs
+++ b/loop-safe-change-feed/source/Enrichment/EnrichmentBootstrapper.cs
@@ -1,0 +1,34 @@
+using Microsoft.Azure.Cosmos;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// Creates the database, the documents container, and the change-feed lease container when they
+/// don't already exist. In Azure these are pre-created by the azd/Bicep deployment; locally
+/// against the emulator this creates them on first run so the sample works with zero setup.
+/// </summary>
+public static class EnrichmentBootstrapper
+{
+    public static async Task EnsureContainersAsync(
+        CosmosClient client,
+        EnrichmentOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        Database database = await client.CreateDatabaseIfNotExistsAsync(
+            options.DatabaseName, cancellationToken: cancellationToken);
+
+        await database.CreateContainerIfNotExistsAsync(new ContainerProperties
+        {
+            Id = options.ContainerName,
+            PartitionKeyPath = "/id",
+        }, cancellationToken: cancellationToken);
+
+        // The change feed processor stores its position (leases) here. Partitioned on /id like any
+        // Cosmos container; the processor manages the documents inside it.
+        await database.CreateContainerIfNotExistsAsync(new ContainerProperties
+        {
+            Id = options.LeaseContainerName,
+            PartitionKeyPath = "/id",
+        }, cancellationToken: cancellationToken);
+    }
+}

--- a/loop-safe-change-feed/source/Enrichment/EnrichmentOptions.cs
+++ b/loop-safe-change-feed/source/Enrichment/EnrichmentOptions.cs
@@ -1,0 +1,35 @@
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// Configuration for the change-feed enrichment pattern. Every property name is configurable so
+/// the pattern is generic: point <see cref="SourceProperty"/> at whatever field drives the
+/// derived value, and store the result in <see cref="EnrichedProperty"/> alongside a loop-guard
+/// hash in <see cref="HashProperty"/>.
+/// </summary>
+public sealed class EnrichmentOptions
+{
+    /// <summary>Database that holds both the documents and the change-feed lease container.</summary>
+    public string DatabaseName { get; set; } = "EnrichDB";
+
+    /// <summary>Container that is both the source of changes and the target of in-place writes.</summary>
+    public string ContainerName { get; set; } = "Documents";
+
+    /// <summary>Lease container used by the change feed processor to track its position.</summary>
+    public string LeaseContainerName { get; set; } = "leases";
+
+    /// <summary>The document property whose value drives enrichment (the "source" input).</summary>
+    public string SourceProperty { get; set; } = "text";
+
+    /// <summary>The property where the derived value (here, an identicon SVG) is written.</summary>
+    public string EnrichedProperty { get; set; } = "identicon";
+
+    /// <summary>
+    /// The property that stores the hash of the source. This is the loop guard: after an
+    /// enrichment write re-triggers the change feed, the recomputed source hash matches the
+    /// stored one, so the change is skipped instead of causing an endless loop.
+    /// </summary>
+    public string HashProperty { get; set; } = "sourceHash";
+
+    /// <summary>Logical name of the change feed processor (stored in the lease documents).</summary>
+    public string ProcessorName { get; set; } = "enrichment";
+}

--- a/loop-safe-change-feed/source/Enrichment/IdenticonGenerator.cs
+++ b/loop-safe-change-feed/source/Enrichment/IdenticonGenerator.cs
@@ -1,0 +1,73 @@
+using System.Globalization;
+using System.Text;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// Turns a hex hash into a deterministic, GitHub-style 5x5 symmetric identicon rendered as an
+/// inline SVG string. The same hash always produces the same image; a different hash produces a
+/// visibly different one. It is pure and dependency-free, so it stands in for any real enrichment
+/// step you might plug in instead (embeddings, translation, classification, summarization, ...).
+/// Because the picture is derived from the hash, watching the identicon change in the UI is
+/// literally watching the loop-guard hash change.
+/// </summary>
+public static class IdenticonGenerator
+{
+    /// <summary>Renders a square identicon SVG (default 120x120) from a hex hash.</summary>
+    public static string ToSvg(string hashHex, int pixels = 120)
+    {
+        byte[] bytes = Convert.FromHexString(hashHex);
+        string color = ColorFromBytes(bytes);
+
+        var sb = new StringBuilder();
+        sb.Append(CultureInfo.InvariantCulture,
+            $"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{pixels}\" height=\"{pixels}\" viewBox=\"0 0 5 5\" shape-rendering=\"crispEdges\" role=\"img\">");
+        sb.Append("<rect width=\"5\" height=\"5\" fill=\"#f4f4f5\"/>");
+
+        // Fill the left three columns from the hash, then mirror columns 0 and 1 to 4 and 3 so
+        // the result is vertically symmetric (the classic identicon look).
+        for (int col = 0; col < 3; col++)
+        {
+            for (int row = 0; row < 5; row++)
+            {
+                int cell = col * 5 + row; // 0..14
+                bool filled = (bytes[cell] & 1) == 0; // even byte => filled (~50%)
+                if (!filled) continue;
+                AppendCell(sb, col, row, color);
+                if (col < 2) AppendCell(sb, 4 - col, row, color);
+            }
+        }
+
+        sb.Append("</svg>");
+        return sb.ToString();
+    }
+
+    private static void AppendCell(StringBuilder sb, int x, int y, string color) =>
+        sb.Append(CultureInfo.InvariantCulture, $"<rect x=\"{x}\" y=\"{y}\" width=\"1\" height=\"1\" fill=\"{color}\"/>");
+
+    private static string ColorFromBytes(byte[] b)
+    {
+        // A single saturated hue chosen from the hash keeps the palette pleasant and varied.
+        double hue = b[0] / 255.0 * 360.0;
+        return HslToHex(hue, 0.60, 0.50);
+    }
+
+    private static string HslToHex(double h, double s, double l)
+    {
+        double c = (1 - Math.Abs(2 * l - 1)) * s;
+        double x = c * (1 - Math.Abs((h / 60.0 % 2) - 1));
+        double m = l - c / 2;
+        (double r, double g, double bl) = h switch
+        {
+            < 60 => (c, x, 0.0),
+            < 120 => (x, c, 0.0),
+            < 180 => (0.0, c, x),
+            < 240 => (0.0, x, c),
+            < 300 => (x, 0.0, c),
+            _ => (c, 0.0, x),
+        };
+        return $"#{ToByte(r, m):x2}{ToByte(g, m):x2}{ToByte(bl, m):x2}";
+    }
+
+    private static int ToByte(double channel, double m) => (int)Math.Round((channel + m) * 255);
+}

--- a/loop-safe-change-feed/source/Enrichment/ProcessedChange.cs
+++ b/loop-safe-change-feed/source/Enrichment/ProcessedChange.cs
@@ -1,0 +1,25 @@
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// A single observation from the processor, raised for every document the change feed delivers.
+/// Consumers (the console logger, the web timeline) use it to visualize why the loop is bounded:
+/// one <see cref="EnrichmentKind.Enriched"/> per real source change, followed by exactly one
+/// <see cref="EnrichmentKind.Skipped"/> (the echo of that write).
+/// </summary>
+/// <param name="DocumentId">The document's id.</param>
+/// <param name="Kind">What happened (enriched, skipped, or superseded).</param>
+/// <param name="OldHash">The hash stored on the document before this change.</param>
+/// <param name="NewHash">The recomputed source hash.</param>
+/// <param name="SourceValue">The source value (included for enriched changes so UIs can show it).</param>
+/// <param name="TotalWrites">Running count of write-backs since the processor started.</param>
+/// <param name="TotalSkips">Running count of skipped echoes since the processor started.</param>
+/// <param name="Timestamp">When the change was processed (UTC).</param>
+public sealed record ProcessedChange(
+    string DocumentId,
+    EnrichmentKind Kind,
+    string? OldHash,
+    string? NewHash,
+    string? SourceValue,
+    long TotalWrites,
+    long TotalSkips,
+    DateTimeOffset Timestamp);

--- a/loop-safe-change-feed/source/Enrichment/SourceHasher.cs
+++ b/loop-safe-change-feed/source/Enrichment/SourceHasher.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// Computes a stable hash of the source value. The hash is stored on the document and recomputed
+/// every time the change feed delivers the document; comparing the two is what tells us whether
+/// the source actually changed (enrich) or whether we're seeing the echo of our own write (skip).
+/// </summary>
+public static class SourceHasher
+{
+    /// <summary>Returns a lowercase hex SHA-256 of the source value (empty string when null).</summary>
+    public static string Compute(string? sourceValue)
+    {
+        byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sourceValue ?? string.Empty));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/loop-safe-change-feed/source/Processor/Processor.csproj
+++ b/loop-safe-change-feed/source/Processor/Processor.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>ChangeFeedEnrichment.Processor</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Enrichment\Enrichment.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/loop-safe-change-feed/source/Processor/Program.cs
+++ b/loop-safe-change-feed/source/Processor/Program.cs
@@ -1,0 +1,136 @@
+using Cosmos.ChangeFeedEnrichment;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using System.Net;
+
+// -----------------------------------------------------------------------------------------------
+// Loop-Safe Change Feed Enrichment — console sample.
+//
+// A Change Feed Processor watches the "Documents" container and writes an enriched value (here a
+// deterministic identicon SVG derived from a hash of the source text) back onto the SAME document
+// in the SAME container. Writing to the same container you read from would normally loop forever,
+// because each write is itself a change. The loop is broken by hashing the SOURCE text: after the
+// enrichment write re-triggers the feed, the recomputed source hash matches the stored hash, so
+// the change is skipped instead of re-enriched.
+//
+// This program starts the processor and then makes a few source edits so you can watch, in the
+// log, one ENRICHED per real edit followed by exactly one SKIPPED echo. The writes-vs-skips
+// summary at the end shows the loop is bounded.
+// -----------------------------------------------------------------------------------------------
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddEnvironmentVariables()
+    .Build();
+
+string endpoint = config["CosmosUri"] ?? string.Empty;
+string? key = config["CosmosKey"];
+
+// Default to the local Cosmos DB emulator when nothing is configured (zero-setup local runs).
+if (string.IsNullOrWhiteSpace(endpoint))
+{
+    endpoint = "https://localhost:8081";
+    if (string.IsNullOrEmpty(key))
+    {
+        key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+    }
+}
+
+var options = new EnrichmentOptions();
+
+Console.WriteLine("Azure Cosmos DB — Loop-Safe Change Feed Enrichment");
+Console.WriteLine();
+Console.WriteLine($"Ensuring {options.DatabaseName}/{options.ContainerName} (and lease container) exist...");
+
+using CosmosClient client = CosmosClientFactory.Create(endpoint, key);
+await EnrichmentBootstrapper.EnsureContainersAsync(client, options);
+Container container = client.GetContainer(options.DatabaseName, options.ContainerName);
+
+var consoleLock = new object();
+void Log(ProcessedChange c)
+{
+    (ConsoleColor color, string label) = c.Kind switch
+    {
+        EnrichmentKind.Enriched => (ConsoleColor.Green, "ENRICHED "),
+        EnrichmentKind.Skipped => (ConsoleColor.DarkGray, "SKIPPED  "),
+        _ => (ConsoleColor.Yellow, "SUPERSED."),
+    };
+
+    string detail = c.Kind switch
+    {
+        EnrichmentKind.Enriched => $"source hash {Short(c.OldHash)} -> {Short(c.NewHash)}  (\"{c.SourceValue}\")",
+        EnrichmentKind.Skipped => $"source hash unchanged ({Short(c.NewHash)}) — echo of our own write, no re-enrichment",
+        _ => "a newer edit superseded this change; the newer one will enrich",
+    };
+
+    lock (consoleLock)
+    {
+        Console.ForegroundColor = color;
+        Console.WriteLine($"[{c.Timestamp.LocalDateTime:HH:mm:ss}] {label} {c.DocumentId,-8} writes={c.TotalWrites} skips={c.TotalSkips}  {detail}");
+        Console.ResetColor();
+    }
+}
+
+static string Short(string? hash) => string.IsNullOrEmpty(hash) ? "(none)" : hash[..Math.Min(8, hash.Length)];
+
+await using var processor = new ChangeFeedEnrichmentProcessor(client, options);
+processor.Processed += Log;
+
+Console.WriteLine("Starting the change feed processor (Ctrl+C to stop)...");
+Console.WriteLine();
+await processor.StartAsync();
+
+// Give the processor a moment to acquire leases before we start making edits.
+await Task.Delay(TimeSpan.FromSeconds(3));
+
+async Task WriteSourceAsync(string id, string text)
+{
+    // Read-modify-write so an edit preserves the other fields (including the stored hash), exactly
+    // as a real application editing only the source text would. That lets the log show the real
+    // hash transition (old -> new) rather than starting from scratch each time.
+    JObject doc;
+    try
+    {
+        ItemResponse<JObject> existing = await container.ReadItemAsync<JObject>(id, new PartitionKey(id));
+        doc = existing.Resource;
+    }
+    catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+    {
+        doc = new JObject { ["id"] = id };
+    }
+
+    doc[options.SourceProperty] = text;
+    await container.UpsertItemAsync(doc, new PartitionKey(id));
+    lock (consoleLock)
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] EDIT     {id,-8} set {options.SourceProperty} = \"{text}\"");
+        Console.ResetColor();
+    }
+}
+
+// A few source edits. Watch each one produce exactly one ENRICHED then one SKIPPED echo.
+var edits = new (string Id, string Text)[]
+{
+    ("doc-1", "Hello, Cosmos!"),
+    ("doc-1", "Hello, Change Feed!"),
+    ("doc-2", "Loop-safe enrichment"),
+    ("doc-1", "Hashing the source breaks the loop"),
+};
+
+foreach ((string id, string text) in edits)
+{
+    await WriteSourceAsync(id, text);
+    await Task.Delay(TimeSpan.FromSeconds(5));
+}
+
+// Let any final echo settle, then summarize.
+await Task.Delay(TimeSpan.FromSeconds(3));
+
+Console.WriteLine();
+Console.WriteLine($"Summary: {processor.Writes} enrichment writes, {processor.Skips} skipped echoes.");
+Console.WriteLine($"We made {edits.Length} source edits and wrote back {processor.Writes} times — one enrichment per");
+Console.WriteLine("edit, each followed by a skipped echo. The change feed did not loop.");
+Console.WriteLine();
+Console.WriteLine("Done.");

--- a/loop-safe-change-feed/source/Processor/appsettings.json
+++ b/loop-safe-change-feed/source/Processor/appsettings.json
@@ -1,0 +1,4 @@
+{
+  "CosmosUri": "",
+  "CosmosKey": ""
+}

--- a/loop-safe-change-feed/source/Website/App.razor
+++ b/loop-safe-change-feed/source/Website/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(ChangeFeedEnrichmentWeb.Shared.MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(ChangeFeedEnrichmentWeb.Shared.MainLayout)">
+            <p role="alert">Page not found.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/loop-safe-change-feed/source/Website/Pages/Index.razor
+++ b/loop-safe-change-feed/source/Website/Pages/Index.razor
@@ -1,0 +1,253 @@
+@page "/"
+@using Cosmos.ChangeFeedEnrichment
+@implements IAsyncDisposable
+@inject EnrichmentAppService Sim
+
+<div class="page">
+    <header>
+        <h1>Loop-Safe Change Feed Enrichment</h1>
+        <p class="tagline">
+            A change feed processor derives an <strong>identicon</strong> from each document's text and
+            writes it back onto the <em>same</em> document. Writing to the container you read from would
+            normally loop forever &mdash; here it's bounded because we hash the <strong>source</strong>:
+            the echo of our own write matches the stored hash and is skipped.
+        </p>
+    </header>
+
+    @if (_connecting)
+    {
+        <div class="info-banner"><span class="spinner"></span> Connecting to Azure Cosmos DB and starting the change feed processor&hellip;</div>
+    }
+    else if (_initError is not null)
+    {
+        <div class="error-banner"><strong>Couldn't start.</strong> @_initError</div>
+    }
+
+    <section class="stats">
+        <div class="stat writes">
+            <div class="stat-num">@Sim.Writes</div>
+            <div class="stat-label">enrichment writes</div>
+        </div>
+        <div class="stat skips">
+            <div class="stat-num">@Sim.Skips</div>
+            <div class="stat-label">skipped echoes</div>
+        </div>
+        <div class="stat-note">
+            Every real edit produces <strong>one write</strong> (enrich) then <strong>one skip</strong>
+            (the echo). The counts staying in lock-step is the loop being broken &mdash; not running away.
+        </div>
+    </section>
+
+    <div class="columns">
+        <section class="docs">
+            <h2>Documents</h2>
+            <div class="add-row">
+                <input class="add-input" @bind="_newText" @bind:event="oninput"
+                       placeholder="Type some text and add a document&hellip;" @onkeydown="OnAddKeyDown" />
+                <button class="btn primary" @onclick="AddAsync" disabled="@(_connecting || string.IsNullOrWhiteSpace(_newText))">Add</button>
+            </div>
+
+            @if (_docs.Count == 0 && !_connecting)
+            {
+                <p class="empty">No documents yet. Add one above &mdash; its identicon appears a moment later once the processor enriches it.</p>
+            }
+
+            @foreach (DocView doc in _docs)
+            {
+                <div class="card">
+                    <div class="identicon">
+                        @if (!string.IsNullOrEmpty(doc.IdenticonSvg))
+                        {
+                            @((MarkupString)doc.IdenticonSvg)
+                        }
+                        else
+                        {
+                            <div class="pending"><span class="spinner"></span></div>
+                        }
+                    </div>
+                    <div class="card-body">
+                        <div class="card-id">@doc.Id</div>
+                        <div class="edit-row">
+                            <input class="edit-input" value="@EditText(doc)" @oninput="e => SetEdit(doc.Id, e.Value?.ToString())" />
+                            <button class="btn" @onclick="() => SaveAsync(doc.Id)" disabled="@(!IsDirty(doc))">Save</button>
+                        </div>
+                        <div class="card-hash">
+                            @if (!string.IsNullOrEmpty(doc.Hash))
+                            {
+                                <span class="mono">hash @Short(doc.Hash)</span>
+                            }
+                            else
+                            {
+                                <span class="mono muted">not yet enriched</span>
+                            }
+                            <button class="link-btn" @onclick="() => DeleteAsync(doc.Id)">delete</button>
+                        </div>
+                    </div>
+                </div>
+            }
+        </section>
+
+        <section class="timeline">
+            <h2>Change feed activity</h2>
+            <p class="hint">Newest first. Each save fires the feed twice: once for your edit (<span class="badge enriched">ENRICHED</span>), once for the write-back echo (<span class="badge skipped">SKIPPED</span>).</p>
+            <div class="log">
+                @foreach (ProcessedChange c in _timeline)
+                {
+                    <div class="log-row">
+                        <span class="badge @BadgeClass(c.Kind)">@BadgeText(c.Kind)</span>
+                        <span class="log-doc mono">@c.DocumentId</span>
+                        <span class="log-detail">@Detail(c)</span>
+                        <span class="log-time">@c.Timestamp.LocalDateTime.ToString("HH:mm:ss")</span>
+                    </div>
+                }
+                @if (_timeline.Count == 0)
+                {
+                    <div class="log-empty">No activity yet.</div>
+                }
+            </div>
+        </section>
+    </div>
+</div>
+
+@code {
+    private List<DocView> _docs = new();
+    private IReadOnlyList<ProcessedChange> _timeline = Array.Empty<ProcessedChange>();
+    private readonly Dictionary<string, string> _edits = new();
+    private string _newText = string.Empty;
+    private bool _connecting = true;
+    private string? _initError;
+    private CancellationTokenSource? _cts;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        try
+        {
+            await Sim.EnsureStartedAsync();
+            _connecting = false;
+        }
+        catch (Exception ex)
+        {
+            _connecting = false;
+            _initError = ex.Message;
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        Sim.Changed += OnChanged;
+        await RefreshAsync();
+        await InvokeAsync(StateHasChanged);
+
+        _cts = new CancellationTokenSource();
+        _ = RefreshLoopAsync(_cts.Token);
+    }
+
+    private void OnChanged() => _ = InvokeAsync(async () =>
+    {
+        await RefreshAsync();
+        StateHasChanged();
+    });
+
+    private async Task RefreshLoopAsync(CancellationToken token)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(750));
+        while (await timer.WaitForNextTickAsync(token))
+        {
+            await RefreshAsync();
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            _docs = await Sim.GetDocumentsAsync();
+            _timeline = Sim.Timeline();
+            foreach (DocView d in _docs)
+            {
+                _edits.TryAdd(d.Id, d.Text);
+            }
+        }
+        catch
+        {
+            // Transient read error during refresh; try again on the next tick.
+        }
+    }
+
+    private string EditText(DocView doc) => _edits.TryGetValue(doc.Id, out string? v) ? v : doc.Text;
+    private void SetEdit(string id, string? value) => _edits[id] = value ?? string.Empty;
+    private bool IsDirty(DocView doc) => EditText(doc) != doc.Text && !_connecting;
+
+    private async Task AddAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_newText))
+        {
+            return;
+        }
+
+        string text = _newText;
+        _newText = string.Empty;
+        await Sim.AddDocumentAsync(text);
+        await RefreshAsync();
+    }
+
+    private async Task OnAddKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await AddAsync();
+        }
+    }
+
+    private async Task SaveAsync(string id)
+    {
+        await Sim.SaveSourceAsync(id, EditText(_docs.First(d => d.Id == id)));
+    }
+
+    private async Task DeleteAsync(string id)
+    {
+        _edits.Remove(id);
+        await Sim.DeleteDocumentAsync(id);
+        await RefreshAsync();
+    }
+
+    private static string Short(string? hash) => string.IsNullOrEmpty(hash) ? "" : hash[..Math.Min(8, hash.Length)];
+
+    private static string BadgeClass(EnrichmentKind k) => k switch
+    {
+        EnrichmentKind.Enriched => "enriched",
+        EnrichmentKind.Skipped => "skipped",
+        _ => "superseded",
+    };
+
+    private static string BadgeText(EnrichmentKind k) => k switch
+    {
+        EnrichmentKind.Enriched => "ENRICHED",
+        EnrichmentKind.Skipped => "SKIPPED",
+        _ => "SUPERSEDED",
+    };
+
+    private static string Detail(ProcessedChange c) => c.Kind switch
+    {
+        EnrichmentKind.Enriched => $"source hash {ShortOr(c.OldHash, "none")} → {Short(c.NewHash)}",
+        EnrichmentKind.Skipped => $"hash unchanged ({Short(c.NewHash)}) — echo of our write, no re-enrichment",
+        _ => "superseded by a newer edit",
+    };
+
+    private static string ShortOr(string? hash, string fallback) => string.IsNullOrEmpty(hash) ? fallback : Short(hash);
+
+    public async ValueTask DisposeAsync()
+    {
+        Sim.Changed -= OnChanged;
+        if (_cts is not null)
+        {
+            await _cts.CancelAsync();
+            _cts.Dispose();
+        }
+    }
+}

--- a/loop-safe-change-feed/source/Website/Pages/Index.razor
+++ b/loop-safe-change-feed/source/Website/Pages/Index.razor
@@ -5,7 +5,7 @@
 
 <div class="page">
     <header>
-        <h1>Loop-Safe Change Feed Enrichment</h1>
+        <h1>Loop-Safe Change Feed</h1>
         <p class="tagline">
             A change feed processor derives an <strong>identicon</strong> from each document's text and
             writes it back onto the <em>same</em> document. Writing to the container you read from would

--- a/loop-safe-change-feed/source/Website/Pages/_Host.cshtml
+++ b/loop-safe-change-feed/source/Website/Pages/_Host.cshtml
@@ -1,0 +1,27 @@
+@page "/"
+@namespace ChangeFeedEnrichmentWeb.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Azure Cosmos DB · Loop-Safe Change Feed — Interactive</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="css/site.css" />
+</head>
+<body>
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/loop-safe-change-feed/source/Website/Program.cs
+++ b/loop-safe-change-feed/source/Website/Program.cs
@@ -1,0 +1,32 @@
+using ChangeFeedEnrichmentWeb;
+using Cosmos.ChangeFeedEnrichment;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Serve static web assets (including the framework's blazor.server.js) from the manifest in every
+// environment. Without this, running outside Development serves a non-interactive page because the
+// Blazor circuit script 404s.
+builder.WebHost.UseStaticWebAssets();
+
+builder.Configuration.AddEnvironmentVariables();
+
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+// One shared service owns the Cosmos client + change feed processor and backs the UI.
+builder.Services.AddSingleton<EnrichmentAppService>();
+builder.Services.AddHostedService<ProcessorStartupService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+}
+
+app.UseStaticFiles();
+app.UseRouting();
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/loop-safe-change-feed/source/Website/Properties/launchSettings.json
+++ b/loop-safe-change-feed/source/Website/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "Website": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5240",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/loop-safe-change-feed/source/Website/Services/EnrichmentAppService.cs
+++ b/loop-safe-change-feed/source/Website/Services/EnrichmentAppService.cs
@@ -1,0 +1,197 @@
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+namespace Cosmos.ChangeFeedEnrichment;
+
+/// <summary>
+/// A lightweight document projection for the UI: the source text plus the derived identicon and
+/// the loop-guard hash (once the processor has enriched it).
+/// </summary>
+public sealed record DocView(string Id, string Text, string? IdenticonSvg, string? Hash);
+
+/// <summary>
+/// Application service behind the Blazor UI. It owns the Cosmos client and the change feed
+/// processor (started once), keeps a rolling log of processed changes for the activity timeline,
+/// and provides simple create/edit/delete operations so users can drive the pattern from a browser.
+/// </summary>
+public sealed class EnrichmentAppService : IAsyncDisposable
+{
+    private readonly string _endpoint;
+    private readonly string? _key;
+    private readonly EnrichmentOptions _options = new();
+    private readonly LinkedList<ProcessedChange> _log = new();
+    private readonly object _sync = new();
+
+    private CosmosClient? _client;
+    private Container? _container;
+    private ChangeFeedEnrichmentProcessor? _processor;
+    private int _started;
+
+    /// <summary>Raised whenever the processor reports a change, so the UI can refresh.</summary>
+    public event Action? Changed;
+
+    public EnrichmentAppService(IConfiguration config)
+    {
+        string endpoint = config["CosmosUri"] ?? string.Empty;
+        string? key = config["CosmosKey"];
+
+        // Default to the local Cosmos DB emulator when nothing is configured (zero-setup local runs).
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            endpoint = "https://localhost:8081";
+            if (string.IsNullOrEmpty(key))
+            {
+                key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+            }
+        }
+
+        _endpoint = endpoint;
+        _key = key;
+    }
+
+    public EnrichmentOptions Options => _options;
+    public long Writes => _processor?.Writes ?? 0;
+    public long Skips => _processor?.Skips ?? 0;
+
+    /// <summary>Creates the containers and starts the change feed processor exactly once.</summary>
+    public async Task EnsureStartedAsync()
+    {
+        if (Interlocked.Exchange(ref _started, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(12));
+            _client = CosmosClientFactory.Create(_endpoint, _key);
+            await EnrichmentBootstrapper.EnsureContainersAsync(_client, _options, cts.Token);
+            _container = _client.GetContainer(_options.DatabaseName, _options.ContainerName);
+
+            _processor = new ChangeFeedEnrichmentProcessor(_client, _options);
+            _processor.Processed += OnProcessed;
+            await _processor.StartAsync(cts.Token);
+        }
+        catch (Exception ex)
+        {
+            Interlocked.Exchange(ref _started, 0);
+            throw new InvalidOperationException(
+                $"Could not reach Azure Cosmos DB at {_endpoint}. If you're running locally, start the emulator with 'docker compose up -d' from the repo root, then reload. ({ex.GetType().Name}: {ex.Message})", ex);
+        }
+    }
+
+    private void OnProcessed(ProcessedChange change)
+    {
+        lock (_sync)
+        {
+            _log.AddFirst(change);
+            while (_log.Count > 100)
+            {
+                _log.RemoveLast();
+            }
+        }
+
+        Changed?.Invoke();
+    }
+
+    public IReadOnlyList<ProcessedChange> Timeline()
+    {
+        lock (_sync)
+        {
+            return _log.ToList();
+        }
+    }
+
+    /// <summary>Returns all documents (newest first) projected for the UI.</summary>
+    public async Task<List<DocView>> GetDocumentsAsync()
+    {
+        var results = new List<DocView>();
+        if (_container is null)
+        {
+            return results;
+        }
+
+        using FeedIterator<JObject> feed = _container.GetItemQueryIterator<JObject>(
+            "SELECT * FROM c ORDER BY c._ts DESC");
+        while (feed.HasMoreResults)
+        {
+            foreach (JObject doc in await feed.ReadNextAsync())
+            {
+                results.Add(new DocView(
+                    doc["id"]?.ToString() ?? string.Empty,
+                    doc[_options.SourceProperty]?.ToString() ?? string.Empty,
+                    doc[_options.EnrichedProperty]?.ToString(),
+                    doc[_options.HashProperty]?.ToString()));
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>Creates a new document with the given source text.</summary>
+    public async Task<string> AddDocumentAsync(string text)
+    {
+        if (_container is null)
+        {
+            throw new InvalidOperationException("The service is not started.");
+        }
+
+        string id = $"doc-{Guid.NewGuid():N}"[..12];
+        var doc = new JObject { ["id"] = id, [_options.SourceProperty] = text };
+        await _container.UpsertItemAsync(doc, new PartitionKey(id));
+        return id;
+    }
+
+    /// <summary>
+    /// Updates only the source text, preserving the other fields (read-modify-write) — just as a
+    /// real application editing the source would. The processor then re-enriches on the next change.
+    /// </summary>
+    public async Task SaveSourceAsync(string id, string text)
+    {
+        if (_container is null)
+        {
+            throw new InvalidOperationException("The service is not started.");
+        }
+
+        JObject doc;
+        try
+        {
+            ItemResponse<JObject> existing = await _container.ReadItemAsync<JObject>(id, new PartitionKey(id));
+            doc = existing.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            doc = new JObject { ["id"] = id };
+        }
+
+        doc[_options.SourceProperty] = text;
+        await _container.UpsertItemAsync(doc, new PartitionKey(id));
+    }
+
+    public async Task DeleteDocumentAsync(string id)
+    {
+        if (_container is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _container.DeleteItemAsync<JObject>(id, new PartitionKey(id));
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Already gone.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_processor is not null)
+        {
+            await _processor.DisposeAsync();
+        }
+
+        _client?.Dispose();
+    }
+}

--- a/loop-safe-change-feed/source/Website/Services/ProcessorStartupService.cs
+++ b/loop-safe-change-feed/source/Website/Services/ProcessorStartupService.cs
@@ -1,0 +1,28 @@
+using Cosmos.ChangeFeedEnrichment;
+
+namespace ChangeFeedEnrichmentWeb;
+
+/// <summary>
+/// Starts the change feed processor when the app boots (App Service runs with "Always On"), so
+/// enrichment happens even before a browser connects. Safe to run alongside the UI's own
+/// defensive start call — <see cref="EnrichmentAppService.EnsureStartedAsync"/> is idempotent.
+/// A failure here (for example the emulator isn't running yet) is swallowed; the UI surfaces a
+/// clear error and retries when someone opens the page.
+/// </summary>
+public sealed class ProcessorStartupService(EnrichmentAppService app, ILogger<ProcessorStartupService> logger)
+    : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await app.EnsureStartedAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Change feed processor did not start at boot; the UI will retry.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/loop-safe-change-feed/source/Website/Shared/MainLayout.razor
+++ b/loop-safe-change-feed/source/Website/Shared/MainLayout.razor
@@ -1,0 +1,3 @@
+@inherits LayoutComponentBase
+
+@Body

--- a/loop-safe-change-feed/source/Website/Website.csproj
+++ b/loop-safe-change-feed/source/Website/Website.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>ChangeFeedEnrichmentWeb</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Enrichment\Enrichment.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/loop-safe-change-feed/source/Website/_Imports.razor
+++ b/loop-safe-change-feed/source/Website/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using ChangeFeedEnrichmentWeb
+@using ChangeFeedEnrichmentWeb.Shared
+@using Cosmos.ChangeFeedEnrichment

--- a/loop-safe-change-feed/source/Website/appsettings.json
+++ b/loop-safe-change-feed/source/Website/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "CosmosUri": "",
+  "CosmosKey": ""
+}

--- a/loop-safe-change-feed/source/Website/wwwroot/css/site.css
+++ b/loop-safe-change-feed/source/Website/wwwroot/css/site.css
@@ -1,0 +1,107 @@
+:root {
+    --bg: #0f172a;
+    --panel: #1e293b;
+    --panel-2: #273449;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --accent: #38bdf8;
+    --green: #22c55e;
+    --gray: #64748b;
+    --amber: #f59e0b;
+    --border: #334155;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+}
+
+.page { max-width: 1200px; margin: 0 auto; padding: 24px; }
+
+header h1 { margin: 0 0 6px; font-size: 26px; }
+.tagline { margin: 0 0 16px; color: var(--muted); max-width: 900px; line-height: 1.5; }
+.tagline strong { color: var(--text); }
+
+.mono { font-family: 'Cascadia Code', 'Consolas', monospace; }
+.muted { color: var(--muted); }
+
+.info-banner, .error-banner {
+    padding: 10px 14px; border-radius: 8px; margin-bottom: 16px; display: flex; align-items: center; gap: 10px;
+}
+.info-banner { background: #0b3a4a; color: #bae6fd; }
+.error-banner { background: #4c1d1d; color: #fecaca; }
+
+.spinner {
+    width: 14px; height: 14px; border: 2px solid rgba(255,255,255,.35);
+    border-top-color: #fff; border-radius: 50%; display: inline-block; animation: spin .8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.stats { display: flex; align-items: center; gap: 20px; background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 16px 20px; margin-bottom: 20px; }
+.stat { text-align: center; min-width: 120px; }
+.stat-num { font-size: 34px; font-weight: 700; line-height: 1; }
+.stat.writes .stat-num { color: var(--green); }
+.stat.skips .stat-num { color: var(--gray); }
+.stat-label { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin-top: 4px; }
+.stat-note { color: var(--muted); font-size: 14px; line-height: 1.5; }
+.stat-note strong { color: var(--text); }
+
+.columns { display: grid; grid-template-columns: 1.2fr 1fr; gap: 20px; }
+@media (max-width: 900px) { .columns { grid-template-columns: 1fr; } }
+
+section.docs, section.timeline { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 18px; }
+section h2 { margin: 0 0 12px; font-size: 18px; }
+
+.add-row { display: flex; gap: 8px; margin-bottom: 14px; }
+.add-input, .edit-input {
+    flex: 1; background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
+    border-radius: 8px; padding: 9px 12px; font-size: 14px;
+}
+.add-input:focus, .edit-input:focus { outline: none; border-color: var(--accent); }
+
+.btn {
+    background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+    border-radius: 8px; padding: 9px 14px; cursor: pointer; font-size: 14px;
+}
+.btn:hover:not(:disabled) { border-color: var(--accent); }
+.btn:disabled { opacity: .45; cursor: not-allowed; }
+.btn.primary { background: var(--accent); color: #06283a; border-color: var(--accent); font-weight: 600; }
+
+.empty { color: var(--muted); font-style: italic; }
+
+.card { display: flex; gap: 14px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 12px; margin-bottom: 12px; align-items: center; }
+.identicon { width: 72px; height: 72px; flex: 0 0 72px; border-radius: 8px; overflow: hidden; background: #f4f4f5; display: flex; align-items: center; justify-content: center; }
+.identicon svg { width: 72px; height: 72px; display: block; }
+.pending { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; background: #1a2536; }
+
+.card-body { flex: 1; min-width: 0; }
+.card-id { font-family: 'Cascadia Code', 'Consolas', monospace; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+.edit-row { display: flex; gap: 8px; margin-bottom: 6px; }
+.card-hash { font-size: 12px; color: var(--muted); display: flex; align-items: center; gap: 12px; }
+
+.link-btn { background: none; border: none; color: var(--muted); cursor: pointer; font-size: 12px; text-decoration: underline; padding: 0; }
+.link-btn:hover { color: #fca5a5; }
+
+.hint { color: var(--muted); font-size: 13px; margin: 0 0 12px; line-height: 1.5; }
+
+.log { display: flex; flex-direction: column; gap: 4px; max-height: 520px; overflow-y: auto; }
+.log-row { display: grid; grid-template-columns: 96px 90px 1fr auto; gap: 10px; align-items: center; padding: 6px 8px; border-radius: 6px; background: var(--panel-2); font-size: 13px; }
+.log-doc { color: var(--muted); overflow: hidden; text-overflow: ellipsis; }
+.log-detail { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.log-time { color: var(--muted); font-size: 12px; }
+.log-empty { color: var(--muted); font-style: italic; padding: 8px; }
+
+.badge { display: inline-block; text-align: center; font-size: 11px; font-weight: 700; letter-spacing: .03em; padding: 3px 6px; border-radius: 5px; }
+.badge.enriched { background: rgba(34,197,94,.18); color: #4ade80; }
+.badge.skipped { background: rgba(100,116,139,.25); color: #cbd5e1; }
+.badge.superseded { background: rgba(245,158,11,.18); color: #fbbf24; }
+
+#blazor-error-ui {
+    display: none; position: fixed; bottom: 0; left: 0; right: 0;
+    background: #7f1d1d; color: #fff; padding: 10px 16px; z-index: 1000;
+}
+#blazor-error-ui .reload, #blazor-error-ui .dismiss { color: #fff; margin-left: 12px; cursor: pointer; }

--- a/tests/CosmosDesignPatterns.Tests/LoopSafeChangeFeed/LoopSafeChangeFeedTests.cs
+++ b/tests/CosmosDesignPatterns.Tests/LoopSafeChangeFeed/LoopSafeChangeFeedTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace CosmosDesignPatterns.Tests.LoopSafeChangeFeed;
+
+/// <summary>
+/// Integration tests for the Loop-Safe Change Feed design pattern.
+///
+/// The pattern enriches a document and writes the result back to the SAME container it was read
+/// from. Doing that naively loops forever, because each write is itself a change. The loop is
+/// broken by storing a hash of the SOURCE property on the document: when the change feed delivers
+/// the echo of our own write, the recomputed source hash matches the stored hash, so the change is
+/// skipped instead of re-enriched.
+///
+/// Like the other pattern tests, these simulate what the Change Feed processor does with direct
+/// container operations (mirroring <c>DocumentEnricher</c> in the pattern source), which keeps the
+/// tests deterministic and free of change-feed timing flakiness.
+///
+/// These tests verify:
+///   - A new document is enriched (derived value + source hash written).
+///   - The echo of that write is SKIPPED — no second write, so the loop can't run away.
+///   - Repeatedly processing after a single edit performs exactly ONE write (bounded loop).
+///   - Changing the source re-enriches; an unchanged source does not.
+///   - The derived value is deterministic from the source.
+/// </summary>
+public class LoopSafeChangeFeedTests : IClassFixture<EmulatorFixture>, IAsyncLifetime
+{
+    private const string SourceProperty = "text";
+    private const string EnrichedProperty = "identicon";
+    private const string HashProperty = "sourceHash";
+
+    private readonly CosmosClient _client;
+    private readonly string _databaseName = $"LoopSafeChangeFeedTest-{Guid.NewGuid():N}";
+    private Container _container = default!;
+
+    public LoopSafeChangeFeedTests(EmulatorFixture fixture)
+    {
+        _client = fixture.Client;
+    }
+
+    public async Task InitializeAsync()
+    {
+        Database db = await EmulatorFixture.WithRetryAsync(() => _client.CreateDatabaseIfNotExistsAsync(_databaseName));
+        _container = await EmulatorFixture.WithRetryAsync(() => db.CreateContainerIfNotExistsAsync("Documents", "/id"));
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _client.GetDatabase(_databaseName).DeleteAsync();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers – mirror SourceHasher / DocumentEnricher in the pattern source.
+    // -----------------------------------------------------------------------
+
+    /// <summary>SHA-256 hex of the source value. The loop guard hashes the SOURCE only.</summary>
+    private static string ComputeHash(string? sourceValue)
+    {
+        byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(sourceValue ?? string.Empty));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>A deterministic derived value standing in for the identicon (derived from the hash).</summary>
+    private static string Derive(string hash) => $"<svg data-hash=\"{hash[..8]}\"/>";
+
+    /// <summary>
+    /// Simulates one delivery of a document to the Change Feed processor. Returns true if it wrote
+    /// back (source changed → enriched), false if it skipped (hash unchanged → echo of our write).
+    /// </summary>
+    private async Task<bool> ProcessOnceAsync(string id)
+    {
+        JObject doc = (await _container.ReadItemAsync<JObject>(id, new PartitionKey(id))).Resource;
+
+        string newHash = ComputeHash(doc[SourceProperty]?.ToString());
+        string? storedHash = doc[HashProperty]?.ToString();
+
+        if (string.Equals(newHash, storedHash, StringComparison.Ordinal))
+        {
+            return false; // Echo of our own write — skip. This is what breaks the loop.
+        }
+
+        doc[EnrichedProperty] = Derive(newHash);
+        doc[HashProperty] = newHash;
+        await _container.ReplaceItemAsync(doc, id, new PartitionKey(id),
+            new ItemRequestOptions { IfMatchEtag = doc["_etag"]?.ToString() });
+        return true;
+    }
+
+    /// <summary>Writes only the source text, preserving other fields (read-modify-write).</summary>
+    private async Task EditSourceAsync(string id, string text)
+    {
+        JObject doc;
+        try
+        {
+            doc = (await _container.ReadItemAsync<JObject>(id, new PartitionKey(id))).Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            doc = new JObject { ["id"] = id };
+        }
+
+        doc[SourceProperty] = text;
+        await _container.UpsertItemAsync(doc, new PartitionKey(id));
+    }
+
+    private async Task<JObject> ReadAsync(string id) =>
+        (await _container.ReadItemAsync<JObject>(id, new PartitionKey(id))).Resource;
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task NewDocument_IsEnriched_WithDerivedValueAndSourceHash()
+    {
+        string id = $"doc-{Guid.NewGuid():N}";
+        await EditSourceAsync(id, "Hello, Cosmos!");
+
+        bool wrote = await ProcessOnceAsync(id);
+
+        Assert.True(wrote);
+        JObject doc = await ReadAsync(id);
+        Assert.Equal(ComputeHash("Hello, Cosmos!"), doc[HashProperty]?.ToString());
+        Assert.False(string.IsNullOrEmpty(doc[EnrichedProperty]?.ToString()));
+    }
+
+    [Fact]
+    public async Task Echo_OfEnrichmentWrite_IsSkipped()
+    {
+        string id = $"doc-{Guid.NewGuid():N}";
+        await EditSourceAsync(id, "loop-safe");
+
+        Assert.True(await ProcessOnceAsync(id));   // first delivery: enriched (a write)
+        Assert.False(await ProcessOnceAsync(id));  // echo of that write: skipped — loop broken
+    }
+
+    [Fact]
+    public async Task ProcessingRepeatedly_AfterOneEdit_WritesExactlyOnce()
+    {
+        string id = $"doc-{Guid.NewGuid():N}";
+        await EditSourceAsync(id, "the loop must be bounded");
+
+        int writes = 0;
+        for (int i = 0; i < 5; i++)
+        {
+            if (await ProcessOnceAsync(id))
+            {
+                writes++;
+            }
+        }
+
+        // Exactly one enrichment for one source edit; every later delivery is a skipped echo.
+        Assert.Equal(1, writes);
+    }
+
+    [Fact]
+    public async Task ChangingSource_ReEnriches_AndChangesDerivedValue()
+    {
+        string id = $"doc-{Guid.NewGuid():N}";
+        await EditSourceAsync(id, "first");
+        Assert.True(await ProcessOnceAsync(id));
+
+        JObject before = await ReadAsync(id);
+        string? hashBefore = before[HashProperty]?.ToString();
+        string? derivedBefore = before[EnrichedProperty]?.ToString();
+
+        await EditSourceAsync(id, "second");
+        Assert.True(await ProcessOnceAsync(id));   // source changed → re-enriched
+
+        JObject after = await ReadAsync(id);
+        Assert.NotEqual(hashBefore, after[HashProperty]?.ToString());
+        Assert.NotEqual(derivedBefore, after[EnrichedProperty]?.ToString());
+    }
+
+    [Fact]
+    public async Task RewritingSameSource_DoesNotReEnrich()
+    {
+        string id = $"doc-{Guid.NewGuid():N}";
+        await EditSourceAsync(id, "unchanged");
+        Assert.True(await ProcessOnceAsync(id));
+
+        // Writing the identical source again does not change the hash, so processing skips.
+        await EditSourceAsync(id, "unchanged");
+        Assert.False(await ProcessOnceAsync(id));
+    }
+
+    [Fact]
+    public void Derivation_IsDeterministic_FromSource()
+    {
+        string hashA1 = ComputeHash("apple");
+        string hashA2 = ComputeHash("apple");
+        string hashB = ComputeHash("banana");
+
+        Assert.Equal(hashA1, hashA2);
+        Assert.Equal(Derive(hashA1), Derive(hashA2));
+        Assert.NotEqual(hashA1, hashB);
+        Assert.NotEqual(Derive(hashA1), Derive(hashB));
+    }
+}


### PR DESCRIPTION
Implements #67 — a new design pattern: **Loop-Safe Change Feed Enrichment**.

## The problem
Enriching a document and writing the result back onto the **same** document (in the same container) is a very common need — embeddings, translations, search-normalized fields, derived metadata. But writing back re-triggers the change feed: your write is itself a change, which fires the processor again, which writes again… an infinite loop that burns RUs forever.

## The mechanism
Store a **hash of the source** on the document. On every change, recompute the source hash and compare:
- **differs** → the source really changed: compute the derived value, store it + the new hash, write.
- **matches** → the echo of our own write: **skip**. No second write, so the loop stops after exactly one enrichment.

The hash covers the **source only** (never the derived value or the hash itself), which is what guarantees the write-back can't re-trigger work. As a bonus this makes processing **idempotent** (change feed is at-least-once), and writes use an **ETag** check so a concurrent user edit is never clobbered.

This is a generalized, dependency-free adaptation of the [cosmos-embeddings-generator](https://github.com/AzureCosmosDB/cosmos-embeddings-generator) (credited in the README), using the **Change Feed Processor** instead of Azure Functions.

## The demo enrichment: identicons
Instead of embeddings, the pluggable enrichment step derives a deterministic GitHub-style **identicon** (inline SVG) from the source hash — so the picture *is* a visualization of the loop-guard hash. Edit the text → hash changes → avatar changes; nothing meaningful changed → skipped.

## What's included
- **`source/Enrichment`** — tiny core library: `SourceHasher`, `IdenticonGenerator` (pure, swap it for real enrichment), `DocumentEnricher` (the decision, isolated from Cosmos), `ChangeFeedEnrichmentProcessor`.
- **`source/Processor`** — console app that runs the processor and makes a few edits, printing one `ENRICHED` + one `SKIPPED` per edit and a summary proving the feed didn't loop.
- **`source/Website`** — interactive Blazor Server front end that hosts the processor: add/edit documents, watch identicons appear, and follow a live **change feed activity** timeline with **writes-vs-skips** counters that stay in lock-step (the loop being bounded, made visible).
- **azd template** (`azure.yaml` + `infra/`) deploying the web app (Always On) over a serverless, keyless Cosmos DB account with `Documents` + `leases` containers.
- Pattern `README.md` + root README entry.

## Verification
Tested end-to-end against the Cosmos DB Linux emulator:
- Console: 4 source edits → 4 enrichment writes + 4 skipped echoes.
- Website (Playwright): identicons render, timeline shows `ENRICHED`/`SKIPPED`, writes/skips climb in lock-step (1/1 → 2/2 …), zero console errors; `blazor.server.js` served in Production.
- All three projects build clean in Release; Bicep compiles.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
